### PR TITLE
Fix provider loading and auth spinner states

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+import httpx
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -231,6 +232,7 @@ class OpenYakAccountStatus(BaseModel):
     is_connected: bool = False
     proxy_url: str = ""
     email: str = ""
+    has_refresh_token: bool = False
 
 
 class OpenYakAccountConnect(BaseModel):
@@ -243,6 +245,46 @@ class OpenYakAccountDisconnect(BaseModel):
     pass
 
 
+def _is_unauthorized_error(exc: Exception) -> bool:
+    return isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 401
+
+
+async def _refresh_openyak_proxy_token(
+    proxy_url: str,
+    refresh_token: str,
+) -> tuple[str, str] | None:
+    """Refresh an OpenYak proxy access token without mutating persisted settings."""
+    if not refresh_token:
+        return None
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{proxy_url}/api/auth/refresh",
+                json={"refresh_token": refresh_token},
+                timeout=15.0,
+            )
+    except Exception as exc:
+        logger.warning("OpenYak token refresh failed: %s", exc)
+        return None
+
+    if resp.status_code != 200:
+        logger.warning(
+            "OpenYak token refresh rejected: HTTP %d - %s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return None
+
+    data = resp.json()
+    access_token = data.get("access_token", "")
+    if not access_token:
+        logger.warning("OpenYak token refresh returned empty access_token")
+        return None
+
+    return access_token, data.get("refresh_token", "") or refresh_token
+
+
 @router.get("/config/openyak-account", response_model=OpenYakAccountStatus)
 async def get_openyak_account_status(settings: SettingsDep) -> OpenYakAccountStatus:
     """Check if an OpenYak account is connected (proxy mode active)."""
@@ -250,6 +292,7 @@ async def get_openyak_account_status(settings: SettingsDep) -> OpenYakAccountSta
         return OpenYakAccountStatus(
             is_connected=True,
             proxy_url=settings.proxy_url,
+            has_refresh_token=bool(settings.proxy_refresh_token),
         )
     return OpenYakAccountStatus(is_connected=False)
 
@@ -269,17 +312,36 @@ async def connect_openyak_account(
     if not proxy_url or not token:
         raise HTTPException(400, "proxy_url and token are required")
 
-    # Validate by trying to list models through the proxy
-    test_provider = OpenRouterProvider(token, base_url=proxy_url + "/v1", provider_id="openyak-proxy")
+    # Validate by trying to list models through the proxy. Existing desktop
+    # installs may hold an expired access token while still having a valid
+    # refresh token, so refresh once on 401 before asking the user to sign in.
+    refresh_token = body.refresh_token.strip()
+
+    async def _list_proxy_models(access_token: str):
+        test_provider = OpenRouterProvider(access_token, base_url=proxy_url + "/v1", provider_id="openyak-proxy")
+        return await test_provider.list_models()
+
     try:
-        models = await test_provider.list_models()
-        if not models:
-            raise HTTPException(400, "Proxy returned no models")
+        models = await _list_proxy_models(token)
     except HTTPException:
         raise
     except Exception as e:
-        logger.warning("OpenYak account connection failed: %s", e)
-        raise HTTPException(400, f"Failed to connect to proxy: {e}")
+        if _is_unauthorized_error(e) and refresh_token:
+            refreshed = await _refresh_openyak_proxy_token(proxy_url, refresh_token)
+            if not refreshed:
+                raise HTTPException(400, "OpenYak session expired. Please sign in again.") from e
+            token, refresh_token = refreshed
+            try:
+                models = await _list_proxy_models(token)
+            except Exception as retry_error:
+                logger.warning("OpenYak account connection failed after token refresh: %s", retry_error)
+                raise HTTPException(400, f"Failed to connect to proxy: {retry_error}") from retry_error
+        else:
+            logger.warning("OpenYak account connection failed: %s", e)
+            raise HTTPException(400, f"Failed to connect to proxy: {e}") from e
+
+    if not models:
+        raise HTTPException(400, "Proxy returned no models")
 
     # Switch the provider registry to use the proxy
     new_provider = OpenRouterProvider(token, base_url=proxy_url + "/v1", provider_id="openyak-proxy")
@@ -295,9 +357,9 @@ async def connect_openyak_account(
     settings.proxy_url = proxy_url
     settings.proxy_token = token
 
-    if body.refresh_token:
-        _update_env_file("OPENYAK_PROXY_REFRESH_TOKEN", body.refresh_token)
-        settings.proxy_refresh_token = body.refresh_token
+    if refresh_token:
+        _update_env_file("OPENYAK_PROXY_REFRESH_TOKEN", refresh_token)
+        settings.proxy_refresh_token = refresh_token
 
     return OpenYakAccountStatus(is_connected=True, proxy_url=proxy_url)
 

--- a/backend/app/provider/openrouter.py
+++ b/backend/app/provider/openrouter.py
@@ -179,6 +179,8 @@ class OpenRouterProvider(OpenAICompatProvider):
         if self._provider_id == "openyak-proxy":
             models_by_id = {m.id: m for m in models}
             for virtual_id, (real_id, display_name) in PLATFORM_FREE_MODELS.items():
+                if virtual_id in models_by_id:
+                    continue
                 source = models_by_id.get(real_id)
                 if source:
                     models.append(

--- a/backend/tests/test_api/test_openyak_account.py
+++ b/backend/tests/test_api/test_openyak_account.py
@@ -1,0 +1,68 @@
+"""Tests for OpenYak account provider sync."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.api.config import OpenYakAccountConnect, connect_openyak_account
+
+pytestmark = pytest.mark.asyncio
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://proxy.test/v1/models")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(str(status_code), request=request, response=response)
+
+
+def _settings():
+    settings = MagicMock()
+    settings.proxy_url = ""
+    settings.proxy_token = ""
+    settings.proxy_refresh_token = ""
+    return settings
+
+
+class TestConnectOpenYakAccount:
+    async def test_refreshes_expired_access_token_before_registering_proxy(self):
+        settings = _settings()
+        registry = MagicMock()
+        registry.refresh_models = AsyncMock(return_value={})
+        created_tokens: list[str] = []
+
+        class FakeOpenRouterProvider:
+            def __init__(self, api_key: str, **_kwargs):
+                self.api_key = api_key
+                created_tokens.append(api_key)
+
+            async def list_models(self):
+                if self.api_key == "expired_access":
+                    raise _http_status_error(401)
+                return [object()]
+
+        body = OpenYakAccountConnect(
+            proxy_url="https://proxy.test",
+            token="expired_access",
+            refresh_token="refresh_token",
+        )
+
+        with patch("app.api.config.OpenRouterProvider", FakeOpenRouterProvider):
+            with patch(
+                "app.api.config._refresh_openyak_proxy_token",
+                AsyncMock(return_value=("fresh_access", "fresh_refresh")),
+            ):
+                with patch("app.api.config._update_env_file") as update_env:
+                    status = await connect_openyak_account(settings, registry, body)
+
+        assert status.is_connected is True
+        assert settings.proxy_url == "https://proxy.test"
+        assert settings.proxy_token == "fresh_access"
+        assert settings.proxy_refresh_token == "fresh_refresh"
+        assert created_tokens == ["expired_access", "fresh_access", "fresh_access"]
+        registered_provider = registry.register.call_args.args[0]
+        assert registered_provider.api_key == "fresh_access"
+        update_env.assert_any_call("OPENYAK_PROXY_TOKEN", "fresh_access")
+        update_env.assert_any_call("OPENYAK_PROXY_REFRESH_TOKEN", "fresh_refresh")

--- a/backend/tests/test_provider/test_openrouter.py
+++ b/backend/tests/test_provider/test_openrouter.py
@@ -4,6 +4,7 @@ These tests require a valid OPENYAK_OPENROUTER_API_KEY in .env.
 """
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.provider.openrouter import OpenRouterProvider
 from app.provider.registry import ProviderRegistry
@@ -87,6 +88,46 @@ class TestOpenRouterConnection:
         tool_call = next(c for c in chunks if c.type == "tool-call")
         assert tool_call.data["name"] == "read"
         assert "file_path" in tool_call.data["arguments"]
+
+
+class TestOpenYakProxyModels:
+    @pytest.mark.asyncio
+    async def test_does_not_duplicate_platform_free_model_when_proxy_returns_it(self):
+        provider = OpenRouterProvider("test-token", provider_id="openyak-proxy")
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": [
+                {
+                    "id": "openrouter/free",
+                    "name": "OpenRouter Free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                    "context_length": 128000,
+                    "top_provider": {},
+                    "architecture": {"modality": "text->text"},
+                    "supported_parameters": ["tools"],
+                },
+                {
+                    "id": "openyak/best-free",
+                    "name": "Yak Free",
+                    "pricing": {"prompt": "0", "completion": "0"},
+                    "context_length": 128000,
+                    "top_provider": {},
+                    "architecture": {"modality": "text->text"},
+                    "supported_parameters": ["tools"],
+                },
+            ],
+        }
+
+        client = MagicMock()
+        client.get = AsyncMock(return_value=response)
+
+        with patch("app.provider.openrouter.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=client)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+            models = await provider.list_models()
+
+        assert [m.id for m in models].count("openyak/best-free") == 1
 
 
 class TestProviderRegistry:

--- a/frontend/src/components/settings/ollama-panel.tsx
+++ b/frontend/src/components/settings/ollama-panel.tsx
@@ -2,7 +2,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { API, queryKeys } from "@/lib/constants";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -13,26 +14,47 @@ import { ModelLibrary } from "./ollama/ollama-library";
 import type { OllamaRuntimeStatus } from "./ollama/types";
 
 export function OllamaPanel() {
-  useTranslation("settings");
+  const { t } = useTranslation("settings");
   const qc = useQueryClient();
   const { setActiveProvider } = useSettingsStore();
 
-  const { data: runtimeStatus, refetch: refetchStatus } = useQuery({
+  const {
+    data: runtimeStatus,
+    refetch: refetchStatus,
+    isError: runtimeStatusError,
+  } = useQuery({
     queryKey: ["ollamaRuntime"],
     queryFn: () => api.get<OllamaRuntimeStatus>(API.OLLAMA.STATUS),
     refetchInterval: 10_000,
+    retry: false,
   });
 
   const { data: installedModels, refetch: refetchModels } = useQuery({
     queryKey: ["ollamaInstalledModels"],
     queryFn: () => api.get<{ models: import("./ollama/types").OllamaModel[] }>(API.OLLAMA.MODELS),
     enabled: !!runtimeStatus?.running,
+    retry: false,
   });
 
   const { data: library } = useQuery({
     queryKey: ["ollamaLibrary"],
     queryFn: () => api.get<import("./ollama/types").LibraryData>(API.OLLAMA.LIBRARY),
+    retry: false,
   });
+
+  if (runtimeStatusError) {
+    return (
+      <div className="space-y-3 py-2">
+        <div className="flex items-center gap-2 text-xs text-[var(--color-destructive)]">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span>{t("ollamaStatusLoadFailed", "Failed to load Ollama status.")}</span>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetchStatus()}>
+          {t("setupRetry", "Retry")}
+        </Button>
+      </div>
+    );
+  }
 
   if (!runtimeStatus) {
     return (

--- a/frontend/src/components/settings/ollama/ollama-setup.tsx
+++ b/frontend/src/components/settings/ollama/ollama-setup.tsx
@@ -7,6 +7,27 @@ import { Button } from "@/components/ui/button";
 import { apiFetch } from "@/lib/api";
 import { API } from "@/lib/constants";
 
+const SETUP_STREAM_IDLE_TIMEOUT_MS = 120_000;
+
+async function readWithIdleTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("Ollama setup timed out while waiting for progress.")),
+          SETUP_STREAM_IDLE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 export function SetupFlow({ onComplete }: { onComplete: () => void }) {
   const { t } = useTranslation("settings");
   const [progress, setProgress] = useState<{
@@ -39,7 +60,7 @@ export function SetupFlow({ onComplete }: { onComplete: () => void }) {
       let buffer = "";
 
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await readWithIdleTimeout(reader);
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
@@ -53,6 +74,7 @@ export function SetupFlow({ onComplete }: { onComplete: () => void }) {
               setProgress(data);
               if (data.status === "error") {
                 setError(data.message || "Setup failed");
+                setProgress(null);
                 return;
               }
               if (data.status === "ready") {
@@ -65,6 +87,8 @@ export function SetupFlow({ onComplete }: { onComplete: () => void }) {
           }
         }
       }
+      setError("Setup ended before Ollama became ready.");
+      setProgress(null);
     } catch (e) {
       setError(String(e));
       setProgress(null);

--- a/frontend/src/components/settings/providers-tab.tsx
+++ b/frontend/src/components/settings/providers-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Eye, EyeOff, X, Check, Loader2, AlertCircle, LogOut, CreditCard, Mail, RotateCw, Cpu, Server, Plug } from "lucide-react";
 import { OpenYakLogo } from "@/components/ui/openyak-logo";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -344,14 +344,6 @@ export function ProvidersTab({ onNavigateTab }: ProvidersTabProps) {
     },
   });
 
-  const openaiLoginMutation = useMutation({
-    mutationFn: async () => {
-      const resp = await api.post<{ auth_url: string }>(API.CONFIG.OPENAI_SUBSCRIPTION_LOGIN, {});
-      if (IS_DESKTOP) await desktopAPI.openExternal(resp.auth_url);
-      else window.open(resp.auth_url, "_blank", "noopener,noreferrer");
-    },
-  });
-
   const openaiDisconnectMutation = useMutation({
     mutationFn: () => api.delete(API.CONFIG.OPENAI_SUBSCRIPTION),
     onSuccess: () => {
@@ -368,27 +360,61 @@ export function ProvidersTab({ onNavigateTab }: ProvidersTabProps) {
   const [openaiPolling, setOpenaiPolling] = useState(false);
   const [callbackUrlInput, setCallbackUrlInput] = useState("");
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const startOpenaiPolling = () => {
+  const stopOpenaiPolling = useCallback(() => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+    setOpenaiPolling(false);
+  }, []);
+
+  const startOpenaiPolling = useCallback(() => {
+    stopOpenaiPolling();
     setOpenaiPolling(true);
+    let consecutiveFailures = 0;
     const interval = setInterval(async () => {
-      const status = await api.get<OpenAISubscriptionStatus>(API.CONFIG.OPENAI_SUBSCRIPTION);
-      if (status.is_connected) {
-        clearInterval(interval);
-        pollingIntervalRef.current = null;
-        setOpenaiPolling(false);
-        refetchOpenaiSub();
-        setActiveProvider("chatgpt");
-        qc.invalidateQueries({ queryKey: queryKeys.models });
+      try {
+        const status = await api.get<OpenAISubscriptionStatus>(API.CONFIG.OPENAI_SUBSCRIPTION);
+        consecutiveFailures = 0;
+        if (status.is_connected) {
+          stopOpenaiPolling();
+          refetchOpenaiSub();
+          setActiveProvider("chatgpt");
+          qc.invalidateQueries({ queryKey: queryKeys.models });
+        }
+      } catch (err) {
+        consecutiveFailures += 1;
+        console.warn("OpenAI subscription auth polling failed", err);
+        if (consecutiveFailures >= 3) {
+          stopOpenaiPolling();
+        }
       }
     }, 2000);
     pollingIntervalRef.current = interval;
-    setTimeout(() => { clearInterval(interval); if (pollingIntervalRef.current === interval) pollingIntervalRef.current = null; setOpenaiPolling(false); }, 300_000);
-  };
+    pollingTimeoutRef.current = setTimeout(stopOpenaiPolling, 300_000);
+  }, [qc, refetchOpenaiSub, setActiveProvider, stopOpenaiPolling]);
+
+  useEffect(() => stopOpenaiPolling, [stopOpenaiPolling]);
+
+  const openaiLoginMutation = useMutation({
+    mutationFn: async () => {
+      const resp = await api.post<{ auth_url: string }>(API.CONFIG.OPENAI_SUBSCRIPTION_LOGIN, {});
+      if (IS_DESKTOP) await desktopAPI.openExternal(resp.auth_url);
+      else window.open(resp.auth_url, "_blank", "noopener,noreferrer");
+    },
+    onSuccess: startOpenaiPolling,
+    onError: stopOpenaiPolling,
+  });
 
   const manualCallbackMutation = useMutation({
     mutationFn: () => api.post<{ success: boolean; email: string }>(API.CONFIG.OPENAI_SUBSCRIPTION_MANUAL_CALLBACK, { callback_url: callbackUrlInput }),
-    onSuccess: () => { setCallbackUrlInput(""); setOpenaiPolling(false); setActiveProvider("chatgpt"); qc.invalidateQueries({ queryKey: queryKeys.models }); },
+    onSuccess: () => { setCallbackUrlInput(""); stopOpenaiPolling(); setActiveProvider("chatgpt"); qc.invalidateQueries({ queryKey: queryKeys.models }); },
   });
 
   interface OllamaRuntimeStatus { binary_installed: boolean; running: boolean; }
@@ -584,13 +610,13 @@ export function ProvidersTab({ onNavigateTab }: ProvidersTabProps) {
                 </div>
               </div>
               <div className="flex gap-2">
-                {openaiSubStatus.needs_reauth && <Button variant="outline" size="sm" onClick={() => { openaiLoginMutation.mutate(); startOpenaiPolling(); }} disabled={openaiLoginMutation.isPending || openaiPolling}>{(openaiLoginMutation.isPending || openaiPolling) ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : <RotateCw className="h-3.5 w-3.5 mr-1.5" />}{t('chatgptSignIn')}</Button>}
+                {openaiSubStatus.needs_reauth && <Button variant="outline" size="sm" onClick={() => openaiLoginMutation.mutate()} disabled={openaiLoginMutation.isPending || openaiPolling}>{(openaiLoginMutation.isPending || openaiPolling) ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : <RotateCw className="h-3.5 w-3.5 mr-1.5" />}{t('chatgptSignIn')}</Button>}
                 <Button variant="ghost" size="sm" onClick={() => openaiDisconnectMutation.mutate()} disabled={openaiDisconnectMutation.isPending}>{openaiDisconnectMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : <LogOut className="h-3.5 w-3.5 mr-1.5" />}{t('disconnect')}</Button>
               </div>
             </div>
           ) : (
             <div className="space-y-2">
-              <Button variant="outline" size="sm" onClick={() => { openaiLoginMutation.mutate(); startOpenaiPolling(); }} disabled={openaiLoginMutation.isPending || openaiPolling}>{(openaiLoginMutation.isPending || openaiPolling) ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}{openaiPolling ? t('chatgptWaiting') : t('chatgptSignIn')}</Button>
+              <Button variant="outline" size="sm" onClick={() => openaiLoginMutation.mutate()} disabled={openaiLoginMutation.isPending || openaiPolling}>{(openaiLoginMutation.isPending || openaiPolling) ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" /> : null}{openaiPolling ? t('chatgptWaiting') : t('chatgptSignIn')}</Button>
               {openaiLoginMutation.isError && <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]"><AlertCircle className="h-3.5 w-3.5 shrink-0" /><span>{t('chatgptLoginFailed')}</span></div>}
               {openaiPolling && (
                 <div className="space-y-2 pt-2">

--- a/frontend/src/hooks/use-models.ts
+++ b/frontend/src/hooks/use-models.ts
@@ -31,8 +31,13 @@ async function ensureDesktopOpenYakAccountSynced(): Promise<void> {
   if (!desktopModelSyncPromise) {
     desktopModelSyncPromise = (async () => {
       try {
-        const status = await api.get<{ is_connected: boolean; proxy_url: string }>(API.CONFIG.OPENYAK_ACCOUNT);
-        if (status.is_connected && status.proxy_url === auth.proxyUrl) return;
+        const status = await api.get<{
+          is_connected: boolean;
+          proxy_url: string;
+          has_refresh_token?: boolean;
+        }>(API.CONFIG.OPENYAK_ACCOUNT);
+        const refreshTokenSynced = !auth.refreshToken || status.has_refresh_token === true;
+        if (status.is_connected && status.proxy_url === auth.proxyUrl && refreshTokenSynced) return;
       } catch {
         // Fall through and force a re-sync.
       }

--- a/frontend/tests/ui/fixtures/openyak-api.ts
+++ b/frontend/tests/ui/fixtures/openyak-api.ts
@@ -92,6 +92,9 @@ export interface OpenYakMockOptions {
   promptErrors?: PromptErrorMock[];
   binaryFailures?: string[];
   healthStatus?: number;
+  ollamaStatusCode?: number;
+  openaiLoginStatus?: number;
+  openaiSubscriptionConnected?: boolean;
   remoteProviderInfoStatus?: number | number[];
   connectorErrors?: ConnectorErrorMock[];
   activeJobs?: ActiveJobMock[];
@@ -1503,10 +1506,23 @@ export async function mockOpenYakApi(page: Page, options: OpenYakMockOptions = {
     if (path === "/api/config/openyak-account") {
       return method === "DELETE"
         ? fulfillJson(route, { success: true })
-        : fulfillJson(route, { is_connected: true, proxy_url: "https://proxy.test" });
+        : fulfillJson(route, { is_connected: true, proxy_url: "https://proxy.test", has_refresh_token: true });
+    }
+    if (path === "/api/config/openai-subscription/login") {
+      if (options.openaiLoginStatus && options.openaiLoginStatus !== 200) {
+        return route.fulfill({
+          status: options.openaiLoginStatus,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Authentication launch unavailable" }),
+        });
+      }
+      return fulfillJson(route, { auth_url: "https://chatgpt.test/auth" });
     }
     if (path === "/api/config/openai-subscription") {
-      return fulfillJson(route, { is_connected: true, email: "chatgpt@openyak.test" });
+      return fulfillJson(route, {
+        is_connected: options.openaiSubscriptionConnected ?? true,
+        email: options.openaiSubscriptionConnected === false ? "" : "chatgpt@openyak.test",
+      });
     }
     if (path === "/api/config/local") {
       if (method !== "GET") {
@@ -1559,7 +1575,24 @@ export async function mockOpenYakApi(page: Page, options: OpenYakMockOptions = {
       state.providerSaves.push(method === "DELETE" ? { deleted: path } : requestJson(request));
       return fulfillJson(route, { success: true });
     }
-    if (path === "/api/ollama/status") return fulfillJson(route, { installed: false, running: false, version: null });
+    if (path === "/api/ollama/status") {
+      if (options.ollamaStatusCode && options.ollamaStatusCode !== 200) {
+        return route.fulfill({
+          status: options.ollamaStatusCode,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Ollama status unavailable" }),
+        });
+      }
+      return fulfillJson(route, {
+        binary_installed: false,
+        running: false,
+        port: 11434,
+        base_url: null,
+        version: null,
+        models_dir: null,
+        disk_usage_bytes: 0,
+      });
+    }
     if (path === "/api/usage") {
       return fulfillJson(route, {
         total_cost: 0.12,

--- a/frontend/tests/ui/openyak-edge-regressions.spec.ts
+++ b/frontend/tests/ui/openyak-edge-regressions.spec.ts
@@ -38,7 +38,7 @@ test.describe("OpenYak edge-state GUI regressions", () => {
     await setupMockedApp(page, undefined, { authConnected: false });
 
     await page.goto("/settings?tab=billing");
-    await expect(page.getByText("Connect an OpenYak account to top up and access premium models.")).toBeVisible();
+    await expect(page.locator("p:visible").filter({ hasText: "Connect an OpenYak account to top up and access premium models." })).toBeVisible();
     await page.getByRole("button", { name: "Go to Settings" }).click();
     await expect(page).toHaveURL(/\/settings\?tab=providers$/);
     await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible();
@@ -102,13 +102,42 @@ test.describe("OpenYak edge-state GUI regressions", () => {
 
     await page.goto("/settings?tab=plugins");
     await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
-    await page.getByPlaceholder("Search...").fill("notion");
+    await page.locator('input[placeholder="Search..."]:visible').fill("notion");
     const notionRow = page.locator("div").filter({ hasText: "Notion" }).filter({ hasText: "Search and update pages" }).first();
     await expect(notionRow).toBeVisible();
     await notionRow.getByRole("switch").click();
 
     await expect(page.getByText("Notion OAuth unavailable")).toBeVisible();
     await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
+    await expectNoAppCrash(page);
+  });
+
+  test("chatgpt auth launch failure stops the waiting state", async ({ page }) => {
+    await setupMockedApp(page, {
+      openaiSubscriptionConnected: false,
+      openaiLoginStatus: 500,
+    });
+
+    await page.goto("/settings?tab=providers");
+    await page.getByRole("button", { name: /ChatGPT Subscription/i }).click();
+    await page.getByRole("button", { name: "Sign in with ChatGPT" }).click();
+
+    await expect(page.getByText("Failed to start authentication")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in with ChatGPT" })).toBeEnabled();
+    await expect(page.getByText("Waiting for authentication...")).toHaveCount(0);
+    await expectNoAppCrash(page);
+  });
+
+  test("ollama status failure shows a retryable error instead of an endless spinner", async ({ page }) => {
+    await setupMockedApp(page, {
+      ollamaStatusCode: 500,
+    });
+
+    await page.goto("/settings?tab=providers");
+    await page.getByRole("button", { name: "Ollama" }).click();
+
+    await expect(page.getByText("Failed to load Ollama status.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
     await expectNoAppCrash(page);
   });
 });


### PR DESCRIPTION
## Summary
- Refresh and resync OpenYak proxy account state when the backend lacks the refresh token, preventing connected-but-no-models states.
- Stop ChatGPT authentication polling when auth launch fails, and clean up polling on success, failure, and unmount.
- Add retryable error states/timeouts for Ollama status/setup loading so spinners do not hang indefinitely.
- Avoid duplicate `openyak/best-free` injection when the proxy already returns it.

## Tests
- `python -m pytest backend/tests/test_provider/test_openrouter.py::TestOpenYakProxyModels backend/tests/test_api/test_openyak_account.py backend/tests/test_provider/test_proxy_auth.py`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:ui -- tests/ui/openyak-edge-regressions.spec.ts`
- Real local Win11 backend/frontend/browser verification with Chromium against localhost frontend and backend.