### PR TITLE
docs: bootstrap CONTEXT.md and ADRs for architecture deepening

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,104 @@
+# OpenYak Context
+
+OpenYak is a local desktop AI workbench for office workflows: turning files, threads, and messy office context into deliverables. This file is the canonical glossary for the domain — names used across `backend/`, `frontend/`, and `desktop-tauri/`. Use these terms exactly; treat the listed aliases as words to avoid.
+
+## Language
+
+### Conversation core
+
+**Session**:
+A single ongoing conversation between a user and an Agent, scoped to a Workspace.
+_Avoid_: chat, thread, dialogue.
+
+**Message**:
+A single turn in a Session, authored by either user or assistant.
+_Avoid_: turn, post, entry.
+
+**Part**:
+The atomic content unit inside a Message — text, reasoning, tool call, step-finish, compaction, subtask, or file. Messages are sequences of Parts, not flat strings.
+_Avoid_: block, segment, chunk.
+
+**Compaction**:
+A persistent Part that records summarization and dropped history when the context window is trimmed; the trim is a stored event, not an ephemeral pass.
+_Avoid_: summary, trim, prune.
+
+### Workspace & persistence
+
+**Workspace**:
+A user-bound directory plus its conversational state — where Tools read and write files and where Sessions accumulate. The runtime concept; the persisted record is a Project.
+_Avoid_: folder, repo, directory.
+
+**Project**:
+The ORM record (`backend/app/models/project.py`) that persists a Workspace's path and metadata. One Project = one Workspace.
+_Avoid_: workspace-record (use Project for the row, Workspace for the live concept).
+
+**WorkspaceMemory**:
+Long-term notes scoped to a single Workspace, surfaced into the Agent's system prompt across Sessions.
+_Avoid_: knowledge base, memory.
+
+### AI runtime
+
+**Agent**:
+A configuration bundle (system prompt, model choice, Tool allowlist, PermissionRules) that defines how a Session behaves.
+_Avoid_: persona, assistant, bot.
+
+**Provider**:
+A pluggable backend that produces model output (OpenAI, Anthropic, Ollama, etc.); implements `BaseProvider` in `backend/app/provider/base.py`.
+_Avoid_: model, backend, vendor.
+
+**Tool**:
+A named atomic action the Agent can execute (bash, edit, read, artifact, etc.); implements `ToolDefinition` in `backend/app/tool/base.py`.
+_Avoid_: function, action, capability.
+
+**ToolContext**:
+The bundle of Workspace, Session, and permission state passed to a Tool when it executes; Tools never read globals, they read ToolContext.
+
+**PermissionRule**:
+A declarative rule that gates a Tool by name or regex match (`backend/app/agent/permission.py`); evaluated before the Tool runs, with a user prompt on miss.
+_Avoid_: ACL, gate, policy.
+
+**Skill**:
+A lightweight composed routine — a named preset, smaller than an Agent and larger than a Tool ("a way to do X with these Tools and prompt").
+_Avoid_: workflow, recipe, automation.
+
+### Streaming & output
+
+**GenerationJob**:
+A single streaming model generation, with a stream id, an in-memory event replay buffer, and an abort signal; resumable via Last-Event-ID.
+_Avoid_: stream, request, run.
+
+**Artifact**:
+A reusable, full-document Part rendered in the right-side panel — briefs, tables, plans, diagrams; distinct from inline code blocks.
+_Avoid_: document, output, deliverable.
+
+### Integration
+
+**Channel**:
+A non-OpenYak surface (Slack, Discord, Telegram, Feishu, WeChat, Email, etc.) that injects Messages into a Session and forwards Parts back out; implements `BaseChannel` in `backend/app/channels/base.py`.
+_Avoid_: integration, connector, bot.
+
+## Relationships
+
+- A **Project** owns one **Workspace**; **Sessions** live inside a **Workspace**.
+- A **Session** is a sequence of **Messages**; each **Message** is a sequence of **Parts**.
+- An **Agent** drives a **Session** by calling a **Provider** and dispatching **Tools** through a **ToolContext**.
+- A **PermissionRule** belongs to an **Agent** and gates the **Tools** it may invoke.
+- A **GenerationJob** produces the **Parts** of a single assistant **Message**, streamed via SSE.
+- An **Artifact** is a specific **Part** type; **Compaction** is another.
+- A **Channel** delivers external **Messages** into a **Session** and ships the resulting **Parts** back out.
+- **WorkspaceMemory** is read by an **Agent** at the start of every **Session** in that **Workspace**.
+
+## Example dialogue
+
+> **Dev:** "When the user attaches a deck and asks for a brief, do we store the deck inside the Session?"
+> **Domain expert:** "No — the deck lives in the Workspace as a file. The Session's Message gets a `file` Part that points to it. The Agent reads it through a Tool that takes the path from its ToolContext."
+
+> **Dev:** "If a long Session hits the context window, do we just drop old Messages?"
+> **Domain expert:** "We materialize a Compaction Part — it records what was summarized, the user can see the trim happened, and the Session stays linear."
+
+## Flagged ambiguities
+
+- **Workspace vs. Project** — used interchangeably in places (e.g. `tool/workspace.py` vs. `models/project.py`). Resolved: **Project** is the persisted row; **Workspace** is the live, in-memory binding. Don't say "the Project's workspace"; say "the Workspace" or "the Project record."
+- **Agent vs. Skill vs. Tool** — three scales of "a thing the AI does." Resolved: **Tool** = atomic action, **Skill** = composed routine of Tools+prompt, **Agent** = whole config that owns Skills, Tools, and permissions. Reach for the smallest term that fits.
+- **Artifact vs. Part** — every Artifact is a Part; not every Part is an Artifact. Resolved: say **Part** unless the right-panel rendering specifically matters; then say **Artifact**.
+- **Channel vs. Provider** — both are pluggable adapters. Resolved: a **Provider** generates content (LLM); a **Channel** delivers Messages to and from external surfaces. Never call Slack a Provider.

--- a/docs/adr/0001-tauri-spawns-backend-subprocess.md
+++ b/docs/adr/0001-tauri-spawns-backend-subprocess.md
@@ -1,0 +1,5 @@
+# Backend runs as a subprocess of the Tauri shell
+
+The desktop app (`desktop-tauri/`) spawns the FastAPI backend as a local Python subprocess on launch and the frontend talks to it over HTTP (default port 8000). Tauri commands are reserved for shell-only concerns (file dialogs, system tray, updater); all conversation, Tool, Agent, and Provider logic lives in the backend, not in Rust.
+
+We picked this over moving the engine into Rust/Tauri commands because (a) the same backend is also the remote-access server reachable through Cloudflare Tunnel — one code path serves desktop and mobile web; (b) Python is the pragmatic language for the LLM/Provider ecosystem; (c) the subprocess boundary lets us ship a packaged backend binary that can be tested headless without the desktop shell.

--- a/docs/adr/0002-sqlite-wal-default-store.md
+++ b/docs/adr/0002-sqlite-wal-default-store.md
@@ -1,0 +1,5 @@
+# SQLite with WAL is the default store; PostgreSQL is optional
+
+OpenYak persists Projects, Sessions, Messages, and Parts in SQLite with WAL mode and foreign keys enforced (`backend/app/storage/`). PostgreSQL is configurable for self-hosted or shared deployments but is not the default.
+
+OpenYak is local-first — the user's data lives on their machine, with no server. SQLite ships with Python, runs as a single file inside the app's data directory, and WAL gives us concurrent reader/writer behavior good enough for one user with multiple Sessions and a streaming generation in flight. PostgreSQL stays optional so power users running a shared deployment can point at a real database without forking the data layer.

--- a/docs/adr/0003-messages-are-parts.md
+++ b/docs/adr/0003-messages-are-parts.md
@@ -1,0 +1,5 @@
+# Messages are sequences of Parts, not flat strings
+
+A Message in OpenYak is not a string with a role tag — it is an ordered list of **Parts** (text, reasoning, tool, step-finish, compaction, subtask, file). The Part type is a discriminated union persisted as JSON (`backend/app/schemas/message.py`), and the frontend renders each Part type with a dedicated component (`frontend/src/components/parts/`).
+
+Agent runs are not chat. A single assistant Message routinely contains multiple tool calls, reasoning blocks, sub-task results, and a final synthesis. Flattening this into a string would lose the per-Part state required for the AI-Native UI (tool lifecycle colors, collapsible reasoning, the right-panel artifact view, resumable streaming). The Part shape is also the seam where Compaction and Channel forwarding hook in — both are Part-aware operations.

--- a/docs/adr/0004-streaming-replay-buffer.md
+++ b/docs/adr/0004-streaming-replay-buffer.md
@@ -1,0 +1,5 @@
+# SSE streaming with a per-job replay buffer and Last-Event-ID resume
+
+Each streaming generation is a **GenerationJob** (`backend/app/streaming/manager.py`) with a stream id and a bounded in-memory event ring buffer (~5000 events). The frontend consumes Server-Sent Events; on disconnect/reconnect the client sends `Last-Event-ID`, the server replays from that point, and the frontend dedupes (`frontend/src/lib/sse.ts`, `frontend/src/stores/chat-store.ts`).
+
+A long agent run can take minutes, and the Tauri webview, mobile browser, and remote tunnel all drop connections under real conditions. Plain SSE without resume would force a full regeneration on every blip; switching to WebSockets would still leave us writing our own resume protocol. Buffered SSE is HTTP-friendly (works through any proxy or tunnel), survives reconnects without re-running Tools, and the bound on buffer size keeps it backpressure-safe.

--- a/docs/adr/0005-compaction-is-a-persistent-part.md
+++ b/docs/adr/0005-compaction-is-a-persistent-part.md
@@ -1,0 +1,5 @@
+# Compaction is materialized as a Part, not an ephemeral summarization
+
+When a Session approaches the model's context window, the engine inserts a `compaction` Part into the Message stream that records what was summarized and what was dropped (`backend/app/session/compaction.py`, `backend/app/schemas/message.py`). The pre-compaction history is preserved in the database; only the compaction summary is sent to the model on subsequent turns.
+
+Silent context trimming makes a Session feel like it's "forgetting" — confusing for users and for debuggers. Materializing it as a Part means (a) the UI can render the trim explicitly, (b) the dropped Messages remain recoverable from storage, (c) Channel forwarders see compaction as just another Part type instead of a special case, and (d) replays and exports stay deterministic. The cost is a slightly larger DB footprint, which is acceptable given local-first storage.

--- a/docs/adr/0006-chatchannel-vendortransport.md
+++ b/docs/adr/0006-chatchannel-vendortransport.md
@@ -1,0 +1,8 @@
+# `ChatChannel` is the fast path for chat-style Channels; `VendorTransport` is the injected vendor protocol
+
+Chat-style Channels (Feishu, WeChat, Telegram, Slack, Discord, DingTalk) share ~80% of their scaffolding — webhook dispatch, dedup, allowlist, streaming-card buffer, media pipeline, text chunking. We extract that scaffolding into `ChatChannel(BaseChannel)` with a declarative `ChatProfile` for vendor knobs (transport, edit-throttle, signature scheme). Vendor-specific behavior (authn, send, edit, parse_inbound, upload) is provided through an injected `VendorTransport` Protocol — composition, not subclassing — so each vendor can be unit-tested against a `RecordingTransport`. Email / RSS / voice and other Channels that don't fit the chat shape continue to subclass `BaseChannel` directly.
+
+## Considered options
+
+- **One-verb Channel transducer** (Channel = transducer between vendor `Transport` and MessageBus, single `bind()` method). Rejected: forces interactive logins (WeChat QR) and reactions/commands through the bus, which fights OpenYak's existing patterns and adds indirection without compensating leverage.
+- **Six-protocol composition** (`WebhookVerifier`, `CredentialSource`, `MessageReceiver`, `MessageSender`, `DeltaRenderer`, `LifecycleHook` composed on a `Channel`). Rejected: per-protocol Depth is low, state fragments across protocols, and the flexibility budget only pays off if ≥3 unusual Channels (voice, RSS, batch email) actually ship — OpenYak's current trajectory does not support that bet.

--- a/docs/adr/0007-route-module-thin-api-layer.md
+++ b/docs/adr/0007-route-module-thin-api-layer.md
@@ -1,0 +1,15 @@
+# `backend/app/api/` is a thin `Route` Module; multi-Manager orchestration belongs in the Manager layer
+
+Endpoints in `backend/app/api/` are written with a `Route` decorator family — `route.list / get / create / update / delete` for CRUD, `route.stream / multipart / custom` as in-seam escape hatches. Auth, PermissionRule evaluation, `DomainError → HTTPException` mapping (single global table), and audit are provided by the Module by default; route handlers express only the Manager call. The Manager callable's typed signature is the source of truth for what `Route` injects (via `inspect.signature` at decoration time, fail-fast on mismatch); Managers do not take FastAPI `app.state` or `Request`. Operations that need multiple Manager steps (e.g. `delete_session_cascade`: abort streams + delete uploads + delete row + cleanup index) collapse into a single Manager method — they do **not** orchestrate at the route layer — because that's how the Manager Module earns its Depth and how transactional reasoning stays in one place.
+
+## Considered options
+
+- **Pluggable Concern stack** (per-route `@with_concerns(AuthConcern, PermissionConcern, AuditConcern, ...)`). Rejected: streaming SSE breaks the `before/after` model — Audit fires before stream completion, Idempotency-on-stream is fundamentally broken — and the cognitive cost only pays off above ~5 cross-cutting concerns, while OpenYak has 4 today and no concrete future ones. Future concerns (per-Workspace quota, idempotency) will arrive as named kwargs on the existing decorators (`quota="generation"`, `idempotent=True`), not as a generic plug-in seam — that would be a hypothetical seam (one-adapter rule).
+- **Minimalist `route` + `raw` escape hatch** (unusual endpoints drop entirely out of the kernel onto a raw FastAPI router). Rejected: ~15% of routes (multipart uploads, PDF/Markdown exports, native dialogs) are exactly the routes that most need uniform audit and error mapping — letting them escape outside the seam breaks Locality at the wrong 20%.
+
+## Consequences
+
+- Today's `dict`-returning endpoints (`list_session_files`, `list_session_todos`, etc.) need typed Pydantic response schemas. This is API debt the migration surfaces.
+- Long-lived services (`stream_manager`, `index_manager`) move from `app.state` to module-level singletons so Managers can call them without FastAPI coupling. See ADR-0008.
+- Migration is incremental: `Route` and plain FastAPI `@router.get` coexist during the transition; rewrite proceeds file-by-file, starting with `backend/app/api/sessions.py`.
+- A `TestRouteRegistry` adapter lets unit tests dispatch `(verb, path, body, user) → handler return value` without spinning up the FastAPI app or ASGI lifespan.

--- a/docs/adr/0008-services-are-module-level-singletons.md
+++ b/docs/adr/0008-services-are-module-level-singletons.md
@@ -1,0 +1,10 @@
+# Long-lived services are module-level singletons, not on `app.state`
+
+Long-lived services — `stream_manager`, `index_manager`, `provider_registry`, `tool_registry`, and similar — live as module-level singletons accessed by import (`from app.streaming import get_stream_manager`), not as attributes on FastAPI's `app.state`. The lifespan handler still constructs and shuts them down, but it registers them into the owning module rather than holding them.
+
+This is required by ADR-0007: route handlers under the `Route` Module call into Managers, and Managers do not take FastAPI's `Request` or `app.state`. For multi-step operations like `delete_session_cascade(db, session_id)` to live in the Manager layer (where transactional reasoning belongs), the Manager must be able to reach `stream_manager.abort_session()` and `index_manager.cleanup_session()` without an HTTP-layer dependency. Module-level singletons let the Manager layer collapse multi-step operations cleanly while keeping FastAPI consumption contained to the Route Module and the lifespan.
+
+## Consequences
+
+- Tests replace a singleton via the module's setter (`set_stream_manager_for_tests(...)`) or via dependency injection at the Manager call site for the rare unit test that needs it; not via `app.state` overrides.
+- Background workers and CLI entry points (no FastAPI app) construct and register the same singletons in their own bootstrap, mirroring the lifespan path.

--- a/docs/adr/0009-context-window-prompt-assembler-extraction.md
+++ b/docs/adr/0009-context-window-prompt-assembler-extraction.md
@@ -1,0 +1,23 @@
+# Extract `ContextWindow` and `PromptAssembler` from `SessionPrompt`; keep the step loop intact
+
+`backend/app/session/prompt.py` (~970 lines) interleaves five concerns: model/Provider resolution, system prompt assembly, Message persistence, context-window budgeting + Compaction, and step-retry/continuation policy. Two of those concerns are extracted; the other three stay where they are.
+
+**`ContextWindow`** owns the four-stage funnel today inlined at `prompt.py` ~lines 384–620: `microcompact_messages` → `apply_tool_result_budget` → `context_collapse` → full LLM-based compaction (via an `on_summarize` callback). Public Interface is one method — `fit(messages, scheduled_tools, *, on_summarize, token_counter) -> FitOutcome` — with `FitOutcome(messages, compaction_part, tokens_saved, strategy, summary_metadata)`. The Module is **per-Session stateful**: it carries `_context_collapse_exhausted` and `_consecutive_compact_failures` privately across `fit()` calls (the existing circuit-breaker semantics on `prompt.py:144` and `prompt.py:387`), but those fields are not exposed on the Interface.
+
+**`PromptAssembler`** is a pure module-level function: `assemble(inputs: PromptInputs) -> list[SystemPart]` where `SystemPart = {"text": str, "cache": bool}`. It returns a list rather than a string so callers can place Anthropic-style prompt-cache breakpoints — the existing `BaseProvider.stream_chat` signature already accepts `system: str | list[dict[str, Any]]` ([backend/app/provider/base.py:30](backend/app/provider/base.py#L30)), so this aligns with the Provider Interface as it stands today, even though no caller currently emits the structured form. I/O (loading WorkspaceMemory, FTS status) stays in `SessionPrompt._setup()`; the pure function only receives already-resolved values.
+
+**`LoopController` is deliberately NOT extracted.** Todo recovery, `continuation_attempts`, and microcompact decisions are deeply coupled to step-loop state at `prompt.py:621-651`. Pulling them out would create a leaky Interface — the deletion test fails.
+
+## Considered options
+
+- **Inject `BudgetPolicy` / `CompactionStrategy` / `Compactor` / `PromptSource` Protocols on a Composer** (max-flexibility design). Rejected: of the four, only `CompactionStrategy` (3 production tactics today) and `PromptSource` (3 production sources today) pass the two-adapter rule. `Compactor` has only one adapter (persistence is mandated by ADR-0005, no alternate execution mode), and the speculative sources (Skill extension, A/B router, per-Workspace override) have zero production callers — they would be hypothetical seams. The single funnel inside `ContextWindow` already names its four stages, so a future RAG strategy is a 1-day mechanical insertion at that point, with the second adapter actually existing rather than predicted.
+- **Direct `Provider` injection into `ContextWindow` for summarization** (concrete-class design). Rejected: violates the test constraint that `ContextWindow` must be unit-testable without a live Provider. The callback path lets tests pass `token_counter=lambda m, t: 200_000` and `on_summarize=lambda ms: fake_compaction_result()` without stubbing a full Provider.
+- **`PromptAssembler` returning `str`**. Rejected: silently loses the prompt-cache breakpoint expression that the existing `BaseProvider` Interface already supports — a forward-leaning capability regression with no offsetting simplicity.
+
+## Consequences
+
+- `ContextWindow` is constructed once per Session in `_setup()` and reused across every `fit()` call in `_loop()`.
+- The `on_summarize` callback is a closure SessionPrompt builds — it captures Provider, Agent, model id, and the **pre-compaction WorkspaceMemory queueing logic** (today at `prompt.py:568-589`). `ContextWindow` does not know that WorkspaceMemory exists; the "queue important info before summarization" semantics live inside the callback wrapper. This keeps `ContextWindow`'s domain crisp ("decide whether to summarize") and lets WorkspaceMemory queueing evolve without churning the seam.
+- `FitOutcome.summary_metadata: dict | None` is a passthrough channel — `on_summarize` returns whatever it likes (model id, latency, token count); `ContextWindow` doesn't interpret, the caller logs.
+- Migration is sequenced: **PromptAssembler first** (half-day, mechanical, zero loop-semantics risk), **ContextWindow second** (1–2 days, touches `_loop()` state — must preserve the two circuit-breaker variables exactly).
+- `ContextWindow` and `PromptAssembler` are implementation Modules; **CONTEXT.md is not updated** — neither name surfaces in user-facing concepts (`Compaction`, the user-perceivable concept, is already in CONTEXT.md and its semantics are unchanged by this extraction).

--- a/docs/adr/0010-native-dialog-extraction-deferred.md
+++ b/docs/adr/0010-native-dialog-extraction-deferred.md
@@ -1,0 +1,16 @@
+# Defer `NativeDialog` extraction; add telemetry on `/api/files/browse*` and decide based on real fallback rate
+
+The frontend already implements Tauri-first dispatch for native dialogs ([frontend/src/lib/upload.ts:39-72](frontend/src/lib/upload.ts#L39-L72) and [:77-104](frontend/src/lib/upload.ts#L77-L104)): under `IS_DESKTOP`, `browseFiles()` and `browseDirectory()` call `@tauri-apps/plugin-dialog`'s `open()` directly and only fall back to `POST /api/files/browse*` on import failure. The backend's ~280 lines of platform-dispatch code (`api/files.py:88-405`) therefore runs in two scenarios: (a) Tauri plugin-dialog import fails on desktop — rare, possibly never in production — or (b) a remote-access user triggers `browseFiles()` from a browser, in which case the OS dialog opens on the server and the user can't see it (the path is logically broken in remote mode and is not used; remote uploads go through `<input type="file">` → `/api/files/upload`).
+
+The candidate as originally framed was "extract `NativeDialog` Module to clean up `api/files.py`." Under the deletion test, that extraction would formalize vestigial code: the `_dialog_*` functions have **zero non-route callers** in `backend/`, `frontend/`, or any script. The two endpoints exist solely as a Tauri-failure fallback whose real-world hit rate we don't currently measure.
+
+We therefore defer the extraction. Before the next release we add lightweight telemetry — count + log on `/files/browse` and `/files/browse-directory` — to measure how often the fallback actually triggers. After one release of data:
+
+- If the fallback rate is essentially zero, delete `/files/browse` + `/files/browse-directory` along with all `_dialog_*` / `_dir_dialog_*` platform plumbing in `api/files.py` and the corresponding fallback branches in `frontend/src/lib/upload.ts`. ADR-0001 (Tauri commands are shell-only) and the existing frontend dispatch are sufficient — the backend has no business owning native dialog logic.
+- If the fallback rate is meaningfully nonzero, extract the `NativeDialog` Module per the original deepening plan: `pick_files()` / `pick_directory()` module-level functions, private `_PlatformDialog` Protocol with macOS / Windows / Linux / Fake adapters, lazy platform import inside `_get_impl()`.
+
+## Considered options
+
+- **Extract `NativeDialog` Module now.** Rejected for now: pre-pays maintenance cost on code with no demonstrated production callers. If telemetry shows real usage, this becomes the right answer.
+- **Delete `/api/files/browse*` outright now.** Rejected for now: removes a fallback path without data on whether anyone depends on it. One release of telemetry closes that uncertainty cheaply.
+- **Build a `TauriIpcDialogAdapter` so the backend can call into Tauri's plugin-dialog on desktop.** Rejected: Tauri spawns the Python backend with `stdin(Stdio::null())`, no return channel exists, and `#[tauri::command]` handlers are reachable only from the webview. Adding the channel would require either inverting control via frontend HTTP polling or building a sidecar JSON-RPC stack — weeks of work for a feature the frontend already triggers directly. ADR-0001 (Tauri commands shell-only) is the correct answer; native dialog logic stays where it already runs in the desktop case (frontend-initiated Tauri plugin-dialog).


### PR DESCRIPTION
## Summary

Establishes the canonical domain glossary (`CONTEXT.md`) and 10 ADRs that ground the architecture deepening tracked in #20–#53.

- **CONTEXT.md** — names the project's 17 domain terms (Session, Message, Part, Workspace, Project, Agent, Provider, Tool, ToolContext, PermissionRule, Skill, GenerationJob, Artifact, Compaction, WorkspaceMemory, Channel) with relationships, an example dialogue, and 4 flagged ambiguities. The skill-author convention: implementation names (Manager, Route, ChatChannel, ContextWindow, etc.) deliberately do **not** appear in this file — only user/operator-facing concepts.

- **ADR-0001..0005** — record decisions already baked into the code, so future architecture reviews don't re-litigate them: Tauri spawns the FastAPI backend as a subprocess; SQLite-WAL is the default store; Messages are sequences of Parts; SSE streaming uses a per-job replay buffer with `Last-Event-ID` resume; Compaction is a persistent Part, not ephemeral.

- **ADR-0006..0010** — record the deepening direction surfaced this round, each linked from one or more issues:
  - ADR-0006: `ChatChannel` + `VendorTransport` (#20, #26–#30)
  - ADR-0007: `Route` Module replaces hand-written FastAPI route shells (#24, #31–#53)
  - ADR-0008: long-lived services move from `app.state` to module-level singletons (#21)
  - ADR-0009: `ContextWindow` and `PromptAssembler` extraction from `SessionPrompt` (#22, #25)
  - ADR-0010: `NativeDialog` extraction deferred pending `/files/browse*` telemetry (#23)

No code changes — docs only.

## Test plan

- [ ] `CONTEXT.md` renders correctly on GitHub
- [ ] All 10 ADRs render correctly
- [ ] Cross-references between ADRs are correct (e.g. ADR-0007 ↔ ADR-0008 mutual dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)