### PR TITLE
refactor(session): apply review follow-ups to PromptAssembler extraction

### DIFF
--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -11,6 +11,8 @@ Separation of concerns:
 from __future__ import annotations
 
 import logging
+import os
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
@@ -36,8 +38,9 @@ from app.session.manager import (
 )
 from app.session.system_prompt import (
     SystemPromptParts,
-    _active_skills_from_registry,
+    active_skills_from_registry,
     assemble as assemble_system_prompt,
+    default_platform_name,
     default_tz_name,
     load_project_instructions,
     render_skills_section,
@@ -326,22 +329,7 @@ class SessionPrompt:
             except Exception:
                 logger.debug("Workspace memory injection skipped", exc_info=True)
 
-        # I/O is resolved here so assemble() stays pure (per ADR-0009).
-        import platform as _platform
-        from datetime import datetime as _datetime
-
-        self.system_prompt_parts = assemble_system_prompt(
-            self.agent,
-            directory=self.directory,
-            workspace=self.workspace,
-            fts_status=self.fts_status,
-            workspace_memory_section=self.workspace_memory_section,
-            project_instructions=load_project_instructions(self.directory),
-            skills_summary=render_skills_section(_active_skills_from_registry()),
-            now=_datetime.now(),
-            tz_name=default_tz_name(),
-            platform_name=_platform.system(),
-        )
+        self.system_prompt_parts = self._build_system_prompt_parts()
 
         # --- 5. Merge permission rulesets ---
         # Persisted browser choices arrive as request permissions. Do not read
@@ -911,21 +899,30 @@ class SessionPrompt:
             self.request_permissions,
             self.session_permissions,
         )
-        # I/O is resolved here so assemble() stays pure (per ADR-0009).
-        import platform as _platform
-        from datetime import datetime as _datetime
+        self.system_prompt_parts = self._build_system_prompt_parts()
 
-        self.system_prompt_parts = assemble_system_prompt(
+    # ------------------------------------------------------------------
+    # Internal: gather impure inputs and call the pure assemble().
+    # ------------------------------------------------------------------
+
+    def _build_system_prompt_parts(self) -> SystemPromptParts:
+        """Resolve every impure input and call :func:`assemble_system_prompt`.
+
+        Centralises the I/O resolution shared by :meth:`_setup` and
+        :meth:`rebuild_permissions_and_prompt` so the call sites stay
+        single-line and the impure surface is visible in one place.
+        """
+        return assemble_system_prompt(
             self.agent,
-            directory=self.directory,
+            cwd=self.directory or os.getcwd(),
             workspace=self.workspace,
             fts_status=self.fts_status,
             workspace_memory_section=self.workspace_memory_section,
             project_instructions=load_project_instructions(self.directory),
-            skills_summary=render_skills_section(_active_skills_from_registry()),
-            now=_datetime.now(),
+            skills_summary=render_skills_section(active_skills_from_registry()),
+            now=datetime.now(),
             tz_name=default_tz_name(),
-            platform_name=_platform.system(),
+            platform_name=default_platform_name(),
         )
 
 

--- a/backend/app/session/system_prompt.py
+++ b/backend/app/session/system_prompt.py
@@ -1,14 +1,15 @@
 """System prompt assembly.
 
-The ``assemble`` function is **pure**: it takes already-resolved inputs and
-returns a ``SystemPromptParts``. Callers (today: ``SessionPrompt._setup``)
-resolve I/O upstream — project instructions from disk, the active skill list
-from the registry, the wall-clock time, and the platform name — then hand
-those values in. This makes ``assemble`` deterministic and unit-testable
-without touching the filesystem, the global skill registry, or the clock.
+``assemble`` is a pure function: every input is supplied by the caller. It
+performs no filesystem reads, no skill-registry lookups, and no clock or
+platform calls. Callers (today: ``SessionPrompt``) resolve the impure
+inputs upstream — project instructions from disk, the active skill list
+from the registry, the wall-clock time, the timezone name, the platform
+name, and the working directory — then hand them in.
 
-``build_system_prompt`` is kept as a thin convenience that resolves the I/O
-itself; prefer ``assemble`` in new call sites.
+Resolve helpers exposed publicly: ``load_project_instructions``,
+``render_skills_section``, ``active_skills_from_registry``,
+``default_tz_name``.
 
 Per ADR-0009 (PromptAssembler extraction).
 """
@@ -20,6 +21,7 @@ import platform as _platform
 import time as _time
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Iterable
 
 from app.schemas.agent import AgentInfo
@@ -46,8 +48,7 @@ class SystemPromptParts:
     def as_cached_blocks(self) -> list[dict[str, Any]]:
         """Format as Anthropic system message blocks with cache_control.
 
-        Returns a list suitable for the Anthropic API ``system`` parameter:
-        the cached block gets a ``cache_control`` marker so it is stored
+        The cached block gets a ``cache_control`` marker so it is stored
         server-side and reused across turns within the same session.
         """
         blocks: list[dict[str, Any]] = []
@@ -68,7 +69,7 @@ class SystemPromptParts:
 def assemble(
     agent: AgentInfo,
     *,
-    directory: str | None = None,
+    cwd: str,
     workspace: str | None = None,
     fts_status: dict | None = None,
     workspace_memory_section: str | None = None,
@@ -80,10 +81,12 @@ def assemble(
 ) -> SystemPromptParts:
     """Assemble the system prompt from caller-resolved inputs.
 
-    Pure: no filesystem reads, no registry lookups, no clock calls. Resolve
-    ``project_instructions`` via :func:`load_project_instructions`,
-    ``skills_summary`` via :func:`render_skills_section`, and ``now`` /
-    ``tz_name`` / ``platform_name`` from the caller's environment.
+    Pure: no filesystem reads, no registry lookups, no clock or platform
+    calls. The caller supplies every value, including ``cwd`` (typically
+    ``self.directory or os.getcwd()``). Use the module's resolve helpers
+    (:func:`load_project_instructions`, :func:`render_skills_section`,
+    :func:`active_skills_from_registry`, :func:`default_tz_name`) to gather
+    the inputs.
 
     Tests pin all inputs to assert exact output.
     """
@@ -104,7 +107,7 @@ def assemble(
         dynamic_parts.append(skills_summary)
 
     env_info = _environment_section(
-        directory,
+        cwd=cwd,
         workspace=workspace,
         fts_status=fts_status,
         now=now,
@@ -119,36 +122,14 @@ def assemble(
     )
 
 
-def build_system_prompt(
-    agent: AgentInfo,
-    *,
-    directory: str | None = None,
-    workspace: str | None = None,
-    fts_status: dict | None = None,
-    workspace_memory_section: str | None = None,
-) -> SystemPromptParts:
-    """Backward-compatible convenience wrapper that resolves I/O internally.
-
-    Prefer :func:`assemble` in new call sites — it leaves I/O resolution to
-    the caller, which keeps the assembly step deterministic and testable.
-    """
-    return assemble(
-        agent,
-        directory=directory,
-        workspace=workspace,
-        fts_status=fts_status,
-        workspace_memory_section=workspace_memory_section,
-        project_instructions=load_project_instructions(directory),
-        skills_summary=render_skills_section(_active_skills_from_registry()),
-        now=datetime.now(),
-        tz_name=default_tz_name(),
-        platform_name=_platform.system(),
-    )
-
-
 def default_tz_name() -> str:
     """Return the local timezone name, matching the existing prompt's format."""
     return _time.tzname[_time.daylight] if _time.daylight else _time.tzname[0]
+
+
+def default_platform_name() -> str:
+    """Return the OS platform name."""
+    return _platform.system()
 
 
 def load_project_instructions(directory: str | None) -> str | None:
@@ -185,7 +166,8 @@ def render_skills_section(active_skills: Iterable[Any]) -> str | None:
 
     Each skill must expose ``.name`` and ``.description`` attributes. Returns
     ``None`` when no skills are active. Public helper — callers fetch the
-    skill list (e.g. ``registry.active_skills()``) and pass to :func:`assemble`.
+    skill list (e.g. via :func:`active_skills_from_registry`) and pass it
+    to :func:`assemble`.
 
     The list is duplicated in the system prompt because many models route
     better when relevant capabilities are surfaced there in addition to the
@@ -218,8 +200,11 @@ def render_skills_section(active_skills: Iterable[Any]) -> str | None:
     return "\n".join(lines)
 
 
-def _active_skills_from_registry() -> list[Any]:
-    """Best-effort fetch of currently active skills, sorted by name."""
+def active_skills_from_registry() -> list[Any]:
+    """Best-effort fetch of currently active skills, sorted by name.
+
+    Returns an empty list if the registry is unavailable.
+    """
     try:
         from app.dependencies import get_skill_registry
 
@@ -230,8 +215,8 @@ def _active_skills_from_registry() -> list[Any]:
 
 
 def _environment_section(
-    directory: str | None,
     *,
+    cwd: str,
     workspace: str | None,
     fts_status: dict | None,
     now: datetime,
@@ -239,7 +224,6 @@ def _environment_section(
     platform_name: str,
 ) -> str:
     """Render the environment section from already-resolved values."""
-    cwd = directory or os.getcwd()
     today = now.strftime("%Y-%m-%d")
     current_time = now.strftime("%H:%M")
 
@@ -250,7 +234,6 @@ def _environment_section(
 - Current year: {now.year}"""
 
     if workspace:
-        from pathlib import Path
         output_dir = str(Path(workspace) / "openyak_written")
         section += f"""
 

--- a/backend/tests/test_session/test_prompt_assembler.py
+++ b/backend/tests/test_session/test_prompt_assembler.py
@@ -42,6 +42,7 @@ _PINNED = {
     "now": _now(),
     "tz_name": "PDT",
     "platform_name": "Darwin",
+    "cwd": "/test/cwd",
 }
 
 
@@ -51,10 +52,10 @@ class TestAssemblePureness:
         assert isinstance(parts, SystemPromptParts)
 
     def test_no_global_state_consulted(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Break the helpers that the convenience wrapper would use; assemble()
+        # Break the resolve helpers that callers normally use; assemble()
         # must not touch them.
         monkeypatch.setattr(
-            "app.session.system_prompt._active_skills_from_registry",
+            "app.session.system_prompt.active_skills_from_registry",
             lambda: (_ for _ in ()).throw(RuntimeError("must not be called")),
         )
         monkeypatch.setattr(
@@ -62,7 +63,8 @@ class TestAssemblePureness:
             lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("must not be called")),
         )
 
-        parts = assemble(_agent(), directory="/anywhere", **_PINNED)
+        pinned = {**_PINNED, "cwd": "/anywhere"}
+        parts = assemble(_agent(), **pinned)
         assert "Working directory: /anywhere" in parts.dynamic
 
 
@@ -133,19 +135,16 @@ class TestEnvironmentDeterminism:
             now=pinned_now,
             tz_name="UTC",
             platform_name="Linux",
+            cwd="/srv",
         )
         assert "Current date: 2030-01-02 (09:05 UTC)" in parts.dynamic
         assert "Current year: 2030" in parts.dynamic
         assert "Platform: Linux" in parts.dynamic
 
-    def test_directory_falls_back_to_cwd_when_none(self) -> None:
-        parts = assemble(_agent(), directory=None, **_PINNED)
-        # cwd at test time — just assert the line is present and non-empty.
-        assert "Working directory: " in parts.dynamic
-        line = next(
-            line for line in parts.dynamic.splitlines() if line.startswith("- Working directory: ")
-        )
-        assert len(line) > len("- Working directory: ")
+    def test_cwd_value_appears_verbatim(self) -> None:
+        pinned = {**_PINNED, "cwd": "/explicit/path"}
+        parts = assemble(_agent(), **pinned)
+        assert "Working directory: /explicit/path" in parts.dynamic
 
 
 class TestWorkspaceVsNoWorkspace:
@@ -157,7 +156,8 @@ class TestWorkspaceVsNoWorkspace:
         assert "# File Reference Format" not in parts.dynamic
 
     def test_no_workspace_emits_file_reference_format(self) -> None:
-        parts = assemble(_agent(), workspace=None, directory="/home/u", **_PINNED)
+        pinned = {**_PINNED, "cwd": "/home/u"}
+        parts = assemble(_agent(), workspace=None, **pinned)
         assert "# File Reference Format" in parts.dynamic
         assert "/home/u" in parts.dynamic
         assert "# Workspace Restriction" not in parts.dynamic

--- a/backend/tests/test_session/test_system_prompt.py
+++ b/backend/tests/test_session/test_system_prompt.py
@@ -1,27 +1,55 @@
-"""System prompt builder tests."""
+"""System prompt assembly — integration tests against real Agent prompts.
 
+These tests exercise ``assemble`` against real agent definitions from
+``AgentRegistry`` and the real skill registry, with file-system project
+instructions where applicable. Pure-function tests with pinned inputs live
+in ``test_prompt_assembler.py``.
+
+Per ADR-0009 (PromptAssembler extraction).
+"""
+
+from datetime import datetime
 from pathlib import Path
-
-import pytest
 
 from app.dependencies import set_skill_registry
 from app.skill.registry import SkillRegistry
 from app.agent.agent import AgentRegistry
-from app.session.system_prompt import build_system_prompt
+from app.session.system_prompt import (
+    active_skills_from_registry,
+    assemble,
+    load_project_instructions,
+    render_skills_section,
+)
+
+
+_PINNED = {
+    "now": datetime(2026, 5, 4, 15, 30, 0),
+    "tz_name": "PDT",
+    "platform_name": "Darwin",
+    "cwd": "/test/cwd",
+}
+
+
+def _resolve_io(directory: str | None = None) -> dict:
+    """Mirror SessionPrompt._build_system_prompt_parts I/O resolution."""
+    return {
+        "project_instructions": load_project_instructions(directory),
+        "skills_summary": render_skills_section(active_skills_from_registry()),
+    }
 
 
 class TestSystemPrompt:
     def test_build_agent_has_prompt(self):
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build)
+        parts = assemble(build, **_resolve_io(), **_PINNED)
         prompt = parts.as_plain_text()
         assert "software engineering" in prompt.lower() or "tool" in prompt.lower()
 
     def test_includes_environment(self):
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build)
+        parts = assemble(build, **_resolve_io(), **_PINNED)
         prompt = parts.as_plain_text()
         assert "Working directory" in prompt
         assert "Platform" in prompt
@@ -30,7 +58,7 @@ class TestSystemPrompt:
     def test_plan_agent_prompt(self):
         ar = AgentRegistry()
         plan = ar.get("plan")
-        parts = build_system_prompt(plan)
+        parts = assemble(plan, **_resolve_io(), **_PINNED)
         prompt = parts.as_plain_text()
         assert "PLAN MODE" in prompt or "read-only" in prompt.lower()
 
@@ -40,7 +68,8 @@ class TestSystemPrompt:
 
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build, directory=str(tmp_path))
+        pinned = {**_PINNED, "cwd": str(tmp_path)}
+        parts = assemble(build, **_resolve_io(str(tmp_path)), **pinned)
         prompt = parts.as_plain_text()
         assert "Custom Instructions" in prompt
         assert "Do X and Y" in prompt
@@ -48,14 +77,15 @@ class TestSystemPrompt:
     def test_without_project_instructions(self, tmp_path: Path):
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build, directory=str(tmp_path))
+        pinned = {**_PINNED, "cwd": str(tmp_path)}
+        parts = assemble(build, **_resolve_io(str(tmp_path)), **pinned)
         prompt = parts.as_plain_text()
         assert "Project Instructions" not in prompt
 
     def test_cached_parts_separate_static_from_dynamic(self):
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build)
+        parts = assemble(build, **_resolve_io(), **_PINNED)
         # Agent base prompt is in cached section
         assert "Yakyak" in parts.cached or "tool" in parts.cached.lower()
         # Environment info is in dynamic section
@@ -64,7 +94,7 @@ class TestSystemPrompt:
     def test_as_cached_blocks_format(self):
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build)
+        parts = assemble(build, **_resolve_io(), **_PINNED)
         blocks = parts.as_cached_blocks()
         assert len(blocks) == 2
         # First block (cached) has cache_control
@@ -88,7 +118,7 @@ class TestSystemPrompt:
 
         ar = AgentRegistry()
         build = ar.get("build")
-        parts = build_system_prompt(build)
+        parts = assemble(build, **_resolve_io(), **_PINNED)
 
         assert "Skill Routing" in parts.dynamic
         assert "sheet-helper" in parts.dynamic


### PR DESCRIPTION
## Summary

Picks up the 5 review follow-ups captured in #56's body. Single commit, 4 files, +108/-98.

| # | Follow-up | Outcome |
|---|---|---|
| 1 | DRY `_setup` / `rebuild_permissions_and_prompt` resolve-and-call | Centralised in private `_build_system_prompt_parts()`; both call sites are now one line |
| 2 | Kill `build_system_prompt` wrapper | Deleted. The 8 integration tests in `test_system_prompt.py` are ported to call `assemble()` directly via a small `_resolve_io()` test helper that mirrors `SessionPrompt._build_system_prompt_parts` |
| 3 | Tighten the purity claim | `assemble()` no longer falls back to `os.getcwd()`; the working directory is a required `cwd: str` parameter. The fallback (`self.directory or os.getcwd()`) lives at the single caller |
| 4 | Drop underscore on `_active_skills_from_registry` | Renamed to `active_skills_from_registry`; the leading underscore was misleading given cross-module use |
| 5 | Move inline imports up | `os` + `datetime` lifted to `prompt.py` module top; `from pathlib import Path` lifted to `system_prompt.py` module top; inline `import platform as _platform` / `from datetime import datetime as _datetime` deleted at both call sites. Added a symmetric `default_platform_name()` helper next to `default_tz_name()` so callers can avoid importing `platform` themselves |

## Test plan

- [x] `tests/test_session/` 104/104 passing
- [x] `test_prompt_assembler.py` updated for the `directory→cwd` rename; the obsolete `os.getcwd()` fallback test is replaced with a positive assertion that the `cwd` parameter is plumbed through verbatim
- [x] `test_system_prompt.py` integration tests preserved — every previous case still passes against `assemble()` instead of `build_system_prompt()`
- [ ] Manual smoke test: open a Session in dev, confirm system prompt sent to Provider is byte-identical to `main` output