### PR TITLE
feat(api): add hit-rate telemetry on /files/browse* (#23)

### DIFF
--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -22,6 +22,40 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
+# ---------------------------------------------------------------------------
+# Telemetry — ADR-0010
+# ---------------------------------------------------------------------------
+
+def _log_browse_telemetry(
+    event: str,
+    request: Request | None,
+    outcome: str,
+    *,
+    paths_count: int | None = None,
+    error: str | None = None,
+) -> None:
+    """Emit one structured log line per /files/browse* hit.
+
+    Per ADR-0010 the backend native-dialog code paths may be vestigial —
+    the frontend (`upload.ts`) prefers Tauri's plugin-dialog and only falls
+    back to these endpoints on import failure. After one release of this
+    signal we decide between extraction and deletion based on hit rate.
+    """
+    ua = request.headers.get("user-agent", "") if request is not None else ""
+    caller = "tauri" if "tauri" in ua.lower() else "browser"
+    fields = [
+        f"event={event}",
+        f"outcome={outcome}",
+        f"caller={caller}",
+        f"server={platform.system()}",
+    ]
+    if paths_count is not None:
+        fields.append(f"paths={paths_count}")
+    if error:
+        fields.append(f"error={error[:120]!r}")
+    logger.info("telemetry.files_browse %s", " ".join(fields))
+
 # Upload destination — relative to backend working directory
 UPLOAD_DIR = Path("data/uploads")
 
@@ -88,6 +122,8 @@ def remove_from_hash_index(content_hash: str | None) -> None:
 async def _open_native_file_dialog(
     multiple: bool = True,
     title: str = "Select files",
+    *,
+    request: Request | None = None,
 ) -> list[str]:
     """Open an OS-native file dialog and return selected paths.
 
@@ -107,6 +143,7 @@ async def _open_native_file_dialog(
             return await _dialog_linux(multiple, title)
     except Exception as e:
         logger.warning("Native file dialog failed: %s", e)
+        _log_browse_telemetry("files_browse", request, "error", error=str(e))
         return []
 
 
@@ -228,7 +265,11 @@ async def _dialog_linux(multiple: bool, title: str) -> list[str]:
 # Native directory dialog (platform-specific)
 # ---------------------------------------------------------------------------
 
-async def _open_native_directory_dialog(title: str = "Select directory") -> str | None:
+async def _open_native_directory_dialog(
+    title: str = "Select directory",
+    *,
+    request: Request | None = None,
+) -> str | None:
     """Open an OS-native folder picker and return the selected path."""
     system = platform.system()
     try:
@@ -240,6 +281,7 @@ async def _open_native_directory_dialog(title: str = "Select directory") -> str 
             return await _dir_dialog_linux(title)
     except Exception as e:
         logger.warning("Native directory dialog failed: %s", e)
+        _log_browse_telemetry("files_browse_directory", request, "error", error=str(e))
         return None
 
 
@@ -520,10 +562,19 @@ async def open_with_system(body: FileContentRequest) -> dict[str, str]:
 
 
 @router.post("/files/browse-directory")
-async def browse_directory(body: BrowseDirectoryRequest | None = None) -> dict[str, str | None]:
+async def browse_directory(
+    request: Request,
+    body: BrowseDirectoryRequest | None = None,
+) -> dict[str, str | None]:
     """Open native directory picker dialog. Returns selected path or null."""
     req = body or BrowseDirectoryRequest()
-    path = await _open_native_directory_dialog(title=req.title)
+    path = await _open_native_directory_dialog(title=req.title, request=request)
+    _log_browse_telemetry(
+        "files_browse_directory",
+        request,
+        "success" if path else "cancel",
+        paths_count=1 if path else 0,
+    )
     return {"path": path}
 
 
@@ -567,19 +618,31 @@ async def list_directory(body: ListDirectoryRequest | None = None) -> dict[str, 
 
 
 @router.post("/files/browse")
-async def browse_files(body: BrowseRequest | None = None) -> list[dict[str, Any]]:
+async def browse_files(
+    request: Request,
+    body: BrowseRequest | None = None,
+) -> list[dict[str, Any]]:
     """Open native file dialog and return metadata for selected files.
 
     No files are copied — paths reference the originals.
     """
     req = body or BrowseRequest()
-    paths = await _open_native_file_dialog(multiple=req.multiple, title=req.title)
+    paths = await _open_native_file_dialog(
+        multiple=req.multiple, title=req.title, request=request
+    )
 
     results = []
     for p in paths:
         fp = Path(p)
         if fp.is_file():
             results.append(_file_metadata(fp, source="referenced").model_dump())
+
+    _log_browse_telemetry(
+        "files_browse",
+        request,
+        "success" if results else "cancel",
+        paths_count=len(results),
+    )
     return results
 
 

--- a/backend/tests/test_api/test_files.py
+++ b/backend/tests/test_api/test_files.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 pytestmark = pytest.mark.asyncio
@@ -27,3 +29,136 @@ class TestAttachByPath:
         assert data[1]["path"] == str(folder.resolve())
         assert data[1]["mime_type"] == "inode/directory"
         assert data[1]["size"] == 0
+
+
+def _telemetry_lines(caplog: pytest.LogCaptureFixture, event: str) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "app.api.files"
+        and r.getMessage().startswith("telemetry.files_browse ")
+        and f"event={event}" in r.getMessage()
+    ]
+
+
+class TestBrowseTelemetry:
+    """ADR-0010: every /files/browse* hit emits one structured log line."""
+
+    async def test_browse_files_success(self, app_client, tmp_path, monkeypatch, caplog):
+        target = tmp_path / "doc.md"
+        target.write_text("hello", encoding="utf-8")
+
+        async def fake_dialog(**_kw) -> list[str]:
+            return [str(target)]
+
+        monkeypatch.setattr("app.api.files._open_native_file_dialog", fake_dialog)
+        caplog.set_level(logging.INFO, logger="app.api.files")
+
+        resp = await app_client.post("/api/files/browse", json={"multiple": True, "title": "x"})
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        lines = _telemetry_lines(caplog, "files_browse")
+        assert len(lines) == 1
+        line = lines[0]
+        assert "outcome=success" in line
+        assert "paths=1" in line
+        assert "caller=" in line
+        assert "server=" in line
+
+    async def test_browse_files_cancel(self, app_client, monkeypatch, caplog):
+        async def fake_dialog(**_kw) -> list[str]:
+            return []
+
+        monkeypatch.setattr("app.api.files._open_native_file_dialog", fake_dialog)
+        caplog.set_level(logging.INFO, logger="app.api.files")
+
+        resp = await app_client.post("/api/files/browse", json={})
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+        lines = _telemetry_lines(caplog, "files_browse")
+        assert len(lines) == 1
+        assert "outcome=cancel" in lines[0]
+        assert "paths=0" in lines[0]
+
+    async def test_browse_files_error_outcome_logged(self, app_client, monkeypatch, caplog):
+        # Force the platform-specific dialog to raise so the existing
+        # except: log+swallow path fires; telemetry must still record one
+        # error line.
+        async def boom(*_a, **_kw):
+            raise RuntimeError("zenity not installed")
+
+        monkeypatch.setattr("app.api.files._dialog_windows", boom)
+        monkeypatch.setattr("app.api.files._dialog_macos", boom)
+        monkeypatch.setattr("app.api.files._dialog_linux", boom)
+        caplog.set_level(logging.INFO, logger="app.api.files")
+
+        resp = await app_client.post("/api/files/browse", json={})
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+        lines = _telemetry_lines(caplog, "files_browse")
+        # One error line from the helper, one cancel line from the endpoint
+        # (the helper returned [] after the error, which the endpoint reads
+        # as cancel — that's by design; both lines are useful signal).
+        outcomes = sorted(
+            line.split("outcome=")[1].split(" ")[0] for line in lines
+        )
+        assert outcomes == ["cancel", "error"]
+        error_line = next(line for line in lines if "outcome=error" in line)
+        assert "zenity not installed" in error_line
+
+    async def test_browse_directory_success(self, app_client, monkeypatch, caplog):
+        async def fake_dialog(*_a, **_kw) -> str:
+            return "/picked/path"
+
+        monkeypatch.setattr("app.api.files._open_native_directory_dialog", fake_dialog)
+        caplog.set_level(logging.INFO, logger="app.api.files")
+
+        resp = await app_client.post("/api/files/browse-directory", json={})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"path": "/picked/path"}
+        lines = _telemetry_lines(caplog, "files_browse_directory")
+        assert len(lines) == 1
+        assert "outcome=success" in lines[0]
+        assert "paths=1" in lines[0]
+
+    async def test_browse_directory_cancel(self, app_client, monkeypatch, caplog):
+        async def fake_dialog(*_a, **_kw):
+            return None
+
+        monkeypatch.setattr("app.api.files._open_native_directory_dialog", fake_dialog)
+        caplog.set_level(logging.INFO, logger="app.api.files")
+
+        resp = await app_client.post("/api/files/browse-directory", json={})
+
+        assert resp.status_code == 200
+        assert resp.json() == {"path": None}
+        lines = _telemetry_lines(caplog, "files_browse_directory")
+        assert len(lines) == 1
+        assert "outcome=cancel" in lines[0]
+        assert "paths=0" in lines[0]
+
+    async def test_caller_class_tauri_vs_browser(self, app_client, monkeypatch, caplog):
+        async def fake_dialog(**_kw) -> list[str]:
+            return []
+
+        monkeypatch.setattr("app.api.files._open_native_file_dialog", fake_dialog)
+        caplog.set_level(logging.INFO, logger="app.api.files")
+
+        await app_client.post(
+            "/api/files/browse",
+            json={},
+            headers={"User-Agent": "Mozilla/5.0 Tauri/1.0"},
+        )
+        await app_client.post(
+            "/api/files/browse",
+            json={},
+            headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) Firefox/123"},
+        )
+
+        lines = _telemetry_lines(caplog, "files_browse")
+        assert any("caller=tauri" in line for line in lines)
+        assert any("caller=browser" in line for line in lines)


### PR DESCRIPTION
## Summary

Closes #23. Per ADR-0010 we don't yet know whether the backend native-dialog code paths are reached in production — the frontend ([upload.ts:39-104](frontend/src/lib/upload.ts#L39-L104)) prefers Tauri's plugin-dialog and only falls back to these endpoints on import failure. One release of this signal lets the follow-up issue decide between extracting a `NativeDialog` Module and deleting the endpoints outright.

## What changed

Both `/files/browse` and `/files/browse-directory` now emit **one structured log line per hit** at INFO with a grep-friendly prefix:

```
telemetry.files_browse event=files_browse outcome=success caller=tauri server=Darwin paths=2
telemetry.files_browse event=files_browse_directory outcome=cancel caller=browser server=Linux paths=0
telemetry.files_browse event=files_browse outcome=error caller=browser server=Linux error='zenity not installed'
```

| field | values | source |
|---|---|---|
| `outcome` | success / cancel / error | endpoint result + dialog-helper exception |
| `caller` | tauri / browser | substring match on `User-Agent` |
| `server` | Windows / Darwin / Linux / ... | `platform.system()` |
| `paths` | int | files returned (browse) or 1/0 (browse-directory) |

The error case is logged inside the existing `_open_native_*_dialog` except-and-swallow block, so **HTTP behavior is unchanged** — clients still see `[]` / `{"path": null}` on dialog failure exactly as before. Endpoints additionally log the cancel outcome from the empty result, which is by design (errors and cancels both look like "no paths" to the client; the telemetry distinguishes them).

## Acceptance criteria — all met

- [x] Both endpoints emit a structured log line on every hit, including caller platform and outcome
- [x] Log destination is the project's existing `logger` — no new infrastructure
- [x] Volume is reviewable via `grep telemetry.files_browse` over one release of logs
- [x] No behavior change for end users

## Out of scope

- Counter abstraction — codebase has none today; plain logger lines satisfy the criteria
- Disposition decision (extract vs delete) — explicitly deferred in ADR-0010 to a follow-up issue after one release of data
- Other `app.state.index_manager` reads in this file (e.g. `ingest_files` line 617) — unrelated to ADR-0010 and properly belongs in the #21 follow-up

## Test plan

- [x] `tests/test_api/test_files.py::TestBrowseTelemetry` — 6 new tests covering each outcome, caller class, and the error path
- [x] Full backend suite: 727 passed / 20 pre-existing skips / 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)