### PR TITLE
refactor(api): DomainError hierarchy + global handler (#24 PR-A)

### DIFF
--- a/backend/app/api/sessions.py
+++ b/backend/app/api/sessions.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.api.pdf import markdown_to_pdf
+from app.errors import Conflict, DomainError, InternalError, NotFound, UpstreamError
 from app.dependencies import (
     AgentRegistryDep,
     ProviderRegistryDep,
@@ -197,7 +198,7 @@ async def get_session_endpoint(
     """Get session details."""
     session = await get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise NotFound("Session not found")
     return SessionResponse.model_validate(session)
 
 
@@ -211,7 +212,7 @@ async def update_session_endpoint(
     """Update session fields."""
     session = await get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise NotFound("Session not found")
 
     original_time_updated = session.time_updated
     metadata_only_fields = {"is_pinned", "time_archived"}
@@ -333,10 +334,10 @@ async def compact_session_endpoint(
     
     session = await get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise NotFound("Session not found")
 
     if stream_manager and any(job.session_id == session_id and not job.completed for job in stream_manager._jobs.values()):
-        raise HTTPException(status_code=409, detail="Session is currently generating")
+        raise Conflict("Session is currently generating")
 
     job = GenerationJob(stream_id=f"manual-compact-{generate_ulid()}", session_id=session_id)
     result_payload: dict[str, object] = {"ok": False}
@@ -360,9 +361,9 @@ async def compact_session_endpoint(
                 visible_summary=True,
             )
             if not result.summary and result.pruned_parts == 0:
-                raise HTTPException(status_code=409, detail="Nothing to compact yet")
+                raise Conflict("Nothing to compact yet")
             if not result.summary:
-                raise HTTPException(status_code=502, detail="Compaction pruned context but did not produce an AI summary")
+                raise UpstreamError("Compaction pruned context but did not produce an AI summary")
             result_payload = {
                 "ok": True,
                 "summary_created": True,
@@ -399,7 +400,7 @@ async def delete_session_endpoint(
     await delete_session_uploads(db, session_id)
     deleted = await delete_by_id(db, Session, session_id)
     if not deleted:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise NotFound("Session not found")
 
     # Clean up FTS resources for this session
     index_manager = get_index_manager()
@@ -457,7 +458,7 @@ async def export_session_pdf(
     """Export an entire conversation as a formatted PDF."""
     session = await get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise NotFound("Session not found")
 
     messages = await get_messages(db, session_id)
     title = session.title or "Conversation"
@@ -483,11 +484,11 @@ async def export_session_pdf(
                 ),
             },
         )
-    except HTTPException:
+    except DomainError:
         raise
     except Exception as exc:
         log.exception("Session PDF export failed")
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise InternalError(str(exc)) from exc
 
 
 @router.get("/sessions/{session_id}/export-md")
@@ -498,7 +499,7 @@ async def export_session_markdown(
     """Export an entire conversation as a Markdown file."""
     session = await get_session(db, session_id)
     if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise NotFound("Session not found")
 
     messages = await get_messages(db, session_id)
     title = session.title or "Conversation"

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,0 +1,101 @@
+"""Domain error hierarchy and FastAPI exception handler.
+
+Every layer of the application — manager free functions, services, route
+handlers — raises a :class:`DomainError` subclass instead of
+``fastapi.HTTPException``. A single handler registered via
+:func:`register_error_handlers` translates them to ``JSONResponse`` with the
+subclass's ``status_code`` and a stable ``code`` string.
+
+Why not raise ``HTTPException`` directly:
+
+- It couples the manager layer to the web framework.
+- It makes the response shape ad-hoc per call site (``detail`` strings drift,
+  there is no machine-readable code field).
+- It bypasses any cross-cutting concern (audit log, metrics) we may want to
+  attach at the boundary.
+
+Per ADR-0007 (Route Module + DomainError → HTTPException mapping). Subclass
+list seeded by the categories raised across ``app/api/``: 4xx for client
+errors, 5xx reserved for ``UpstreamError`` (external dependency failed) and
+``InternalError`` (unwrappable 5xx — used sparingly).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+log = logging.getLogger(__name__)
+
+
+class DomainError(Exception):
+    """Base for application errors with a fixed HTTP status mapping."""
+
+    status_code: ClassVar[int] = 500
+    code: ClassVar[str] = "domain_error"
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+class BadInput(DomainError):
+    status_code: ClassVar[int] = 400
+    code: ClassVar[str] = "bad_input"
+
+
+class Unauthenticated(DomainError):
+    status_code: ClassVar[int] = 401
+    code: ClassVar[str] = "unauthenticated"
+
+
+class PermissionDenied(DomainError):
+    status_code: ClassVar[int] = 403
+    code: ClassVar[str] = "permission_denied"
+
+
+class NotFound(DomainError):
+    status_code: ClassVar[int] = 404
+    code: ClassVar[str] = "not_found"
+
+
+class Conflict(DomainError):
+    status_code: ClassVar[int] = 409
+    code: ClassVar[str] = "conflict"
+
+
+class InternalError(DomainError):
+    """Unwrappable 5xx — only when no narrower category fits."""
+
+    status_code: ClassVar[int] = 500
+    code: ClassVar[str] = "internal_error"
+
+
+class UpstreamError(DomainError):
+    """An external dependency (provider, MCP server, OAuth issuer) failed."""
+
+    status_code: ClassVar[int] = 502
+    code: ClassVar[str] = "upstream_error"
+
+
+async def domain_error_handler(request: Request, exc: DomainError) -> JSONResponse:
+    if exc.status_code >= 500:
+        log.error(
+            "DomainError %d %s on %s %s: %s",
+            exc.status_code,
+            type(exc).__name__,
+            request.method,
+            request.url.path,
+            exc.detail,
+        )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail, "code": exc.code},
+    )
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    app.add_exception_handler(DomainError, domain_error_handler)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.auth.middleware import AuthMiddleware
 from app.auth.private_network import PrivateNetworkAccessMiddleware
 from app.auth.token import ensure_session_token
 from app.config import Settings
+from app.errors import register_error_handlers
 from app.dependencies import (
     get_index_manager,
     get_stream_manager,
@@ -661,6 +662,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # privileged endpoint regardless of which interface the request
     # arrived on.
     app.add_middleware(AuthMiddleware)
+
+    # DomainError → JSONResponse. Registered before routers so handlers
+    # raised from any subsequently mounted endpoint are mapped consistently.
+    register_error_handlers(app)
 
     # Mount routers
     app.include_router(health_router)

--- a/backend/tests/test_errors.py
+++ b/backend/tests/test_errors.py
@@ -1,0 +1,117 @@
+"""Tests for the DomainError hierarchy and FastAPI exception handler."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.errors import (
+    BadInput,
+    Conflict,
+    DomainError,
+    InternalError,
+    NotFound,
+    PermissionDenied,
+    Unauthenticated,
+    UpstreamError,
+    register_error_handlers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Subclass status / code mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cls, status, code",
+    [
+        (BadInput, 400, "bad_input"),
+        (Unauthenticated, 401, "unauthenticated"),
+        (PermissionDenied, 403, "permission_denied"),
+        (NotFound, 404, "not_found"),
+        (Conflict, 409, "conflict"),
+        (InternalError, 500, "internal_error"),
+        (UpstreamError, 502, "upstream_error"),
+    ],
+)
+def test_subclass_attributes(cls, status, code):
+    assert cls.status_code == status
+    assert cls.code == code
+    inst = cls("boom")
+    assert inst.detail == "boom"
+    assert str(inst) == "boom"
+    assert isinstance(inst, DomainError)
+
+
+# ---------------------------------------------------------------------------
+# Handler integration — raise from an endpoint, assert response shape
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/notfound")
+    async def _notfound():
+        raise NotFound("missing")
+
+    @app.get("/conflict")
+    async def _conflict():
+        raise Conflict("busy")
+
+    @app.get("/upstream")
+    async def _upstream():
+        raise UpstreamError("provider down")
+
+    @app.get("/badinput")
+    async def _badinput():
+        raise BadInput("nope")
+
+    @app.get("/internal")
+    async def _internal():
+        raise InternalError("oops")
+
+    return app
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path, status, code, detail",
+    [
+        ("/notfound", 404, "not_found", "missing"),
+        ("/conflict", 409, "conflict", "busy"),
+        ("/upstream", 502, "upstream_error", "provider down"),
+        ("/badinput", 400, "bad_input", "nope"),
+        ("/internal", 500, "internal_error", "oops"),
+    ],
+)
+async def test_handler_response_shape(path, status, code, detail):
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(path)
+    assert resp.status_code == status
+    assert resp.json() == {"detail": detail, "code": code}
+
+
+@pytest.mark.asyncio
+async def test_handler_logs_5xx(caplog):
+    """5xx domain errors emit a log line; 4xx do not."""
+    import logging
+
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+
+    with caplog.at_level(logging.ERROR, logger="app.errors"):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.get("/notfound")
+            assert not any("DomainError" in r.message for r in caplog.records)
+
+            await client.get("/upstream")
+            assert any(
+                "DomainError 502 UpstreamError" in r.message and "/upstream" in r.message
+                for r in caplog.records
+            )


### PR DESCRIPTION
First of three PRs landing #24 — see the issue body for the full phasing rationale.

## What changes

- New `app/errors.py` with `DomainError` base + 6 subclasses (`BadInput` 400, `Unauthenticated` 401, `PermissionDenied` 403, `NotFound` 404, `Conflict` 409, `InternalError` 500, `UpstreamError` 502). Each carries a stable `code` string as well as the status.
- Single `register_error_handlers(app)` wires `@app.exception_handler(DomainError)` returning `JSONResponse({detail, code}, status_code=...)`. Registered in `create_app()` before routers.
- Migrates all 10 `HTTPException` raises in `app/api/sessions.py` to domain exceptions:
  - 6× 404 → `NotFound`
  - 2× 409 → `Conflict`
  - 1× 502 (compact didn't produce summary) → `UpstreamError`
  - 1× 500 catch-all → `InternalError`
  - The defensive `except HTTPException: raise` becomes `except DomainError: raise`.

## Why all 10 not just 5

The issue spec proposed migrating 5 raises in `sessions.py` as a smoke test and leaving the rest for PR-C. I went with 10 because the diff cost is the same and a half-migrated `sessions.py` in `main` between PR-A and PR-C is uglier than 10 extra trivial substitutions now. PR-C is then purely about Route decoration + cascade collapse, with zero error-shape concerns.

## Why `UpstreamError` is in PR-A's hierarchy

`compact_session_endpoint` already raises 502 when the provider fails to produce a summary — that's the canonical \"external dependency failed\" case. Pinning the category in PR-A keeps the hierarchy stable before downstream sub-issues #41 (ollama), #46 (mcp), #50 (plugins) start raising it independently in parallel.

## Why `InternalError` is in PR-A's hierarchy (not deferred)

`export_session_pdf` has a catch-all `except Exception → 500 with str(exc)`. The cleanest no-behaviour-change migration is `InternalError(str(exc))`. That `str(exc)` echo is a pre-existing leak smell — not tightening it here, will be revisited in PR-C alongside the broader Route default error path.

## Out of scope (per #24's revised scope)

- `Route` decorator family — PR-B
- `sessions.py` migration to Route + cascade collapse (`delete_session_cascade`, compact cascade) into free functions in `app/session/manager.py` — PR-C
- `TestRouteRegistry` — split out as #60

## Verification

- `tests/test_errors.py`: 13 new tests covering subclass attributes (param matrix), end-to-end handler shape via `httpx.AsyncClient`, and 5xx logging via `caplog`.
- Full suite: 740 passed / 20 skipped (pre-existing). Sessions tests in particular: 16 passed — public HTTP contract unchanged. `code` field is additive (existing clients ignore it).

## Follow-ups for PR-B

Per Item 3 of the review: pin `route.stream` audit semantics in an ADR-0007 addendum before PR-B (open + close/error log lines per stream sharing a `stream_id`; no per-chunk audit).

Refs #24, ADR-0007.