### PR TITLE
docs(adr): pin audit shape for Route Module (#24 PR-B prereq)

### DIFF
--- a/docs/adr/0007-route-module-thin-api-layer.md
+++ b/docs/adr/0007-route-module-thin-api-layer.md
@@ -13,3 +13,30 @@ Endpoints in `backend/app/api/` are written with a `Route` decorator family — 
 - Long-lived services (`stream_manager`, `index_manager`) move from `app.state` to module-level singletons so Managers can call them without FastAPI coupling. See ADR-0008.
 - Migration is incremental: `Route` and plain FastAPI `@router.get` coexist during the transition; rewrite proceeds file-by-file, starting with `backend/app/api/sessions.py`.
 - A `TestRouteRegistry` adapter lets unit tests dispatch `(verb, path, body, user) → handler return value` without spinning up the FastAPI app or ASGI lifespan.
+
+## Addendum: audit shape (2026-05-04)
+
+The original decision said "audit by default" but did not pin what audit looks like. Pinning it here so every `Route`-decorated endpoint emits a uniform shape and downstream tooling (log search, dashboards) can rely on it.
+
+**Non-streaming routes — one line per request, emitted on close:**
+
+```
+logger.info("audit", extra={"user": ..., "route": ..., "status_code": ..., "duration_ms": ...})
+```
+
+Same four-field shape as the `/files/browse*` telemetry shipped in #59 so a single log parser handles both. No new sink, no DB-backed audit table.
+
+**Streaming routes (`route.stream`) — two lines per stream sharing a `stream_id`:**
+
+- **Open** (when the response stream is acquired):
+  `logger.info("audit.stream.open", extra={"stream_id": ..., "user": ..., "route": ..., "started_at": ...})`
+- **Close** (on completion, abort, or error):
+  `logger.info("audit.stream.close", extra={"stream_id": ..., "outcome": "completed" | "aborted" | "error", "duration_ms": ..., "error_class": ...})`
+
+Why two lines instead of one:
+- The single before/after model that `Route` uses for non-streaming requests cannot fire "after" — for SSE the response begins immediately and ends an unbounded time later. Logging only on open loses outcome; logging only on close loses the start signal that a stream existed at all (important for orphan detection if the worker dies mid-stream).
+- A correlated pair is cheap (the `stream_id` already exists in `GenerationJob`) and makes both queries trivial: "how many streams started today" (count opens) and "what fraction completed cleanly" (join on `stream_id`).
+
+**No per-chunk audit.** Considered and rejected: a 30-second generation with 200 chunks × concurrent streams blows up audit volume by 2-3 orders of magnitude with no analytical payoff — chunk-level data is already in the streaming replay buffer (ADR-0004) when needed. The audit layer's unit of accountability is the request lifecycle, not the wire frame.
+
+The decorator owns log emission; route handlers do not call `logger.info("audit ...")` themselves. If a handler needs richer business-event logging it does so under a different logger name to keep the audit channel clean.


### PR DESCRIPTION
Doc-only addendum to [ADR-0007](../tree/adr-0007-streaming-audit/docs/adr/0007-route-module-thin-api-layer.md). Required before #24 PR-B (the `Route` decorator family) so the implementation can't drift from the spec.

## Why this addendum

ADR-0007 declared \"audit by default\" but never pinned what audit looks like. The Considered Options section explicitly noted streaming SSE breaks the generic before/after model — but didn't say what to do about it. PR-B builds the `route.stream` decorator, so we need this nailed down first.

## What it pins

**Non-streaming routes** — one line on close:
```
logger.info(\"audit\", extra={\"user\", \"route\", \"status_code\", \"duration_ms\"})
```
Same four-field shape as the `/files/browse*` telemetry that shipped in #59 — a single log parser handles both.

**Streaming routes** — two lines sharing a `stream_id`:
- `audit.stream.open` on stream acquisition: `{stream_id, user, route, started_at}`
- `audit.stream.close` on completion / abort / error: `{stream_id, outcome, duration_ms, error_class}`

Why two lines, not one: a single before/after fires the after either before the stream really ends (loses outcome) or never (worker dies mid-stream). The correlated pair is cheap — `stream_id` already exists in `GenerationJob` — and makes both \"how many streams started\" and \"what fraction completed cleanly\" trivial queries.

**No per-chunk audit** — explicitly rejected. A 30s generation × 200 chunks × concurrent streams is 2-3 orders of magnitude more lines with no analytical payoff. Chunk-level data already lives in the streaming replay buffer (ADR-0004).

## Why now (independent of PR-A)

PR-A (#61) is the `DomainError` hierarchy — orthogonal to audit. This ADR can land in parallel; PR-B will reference both ADR-0007 (with this addendum) and PR-A's `DomainError` once both are in.

Refs #24, ADR-0007.