### PR TITLE
docs(adr): fix audit-shape format in ADR-0007 addendum

### DIFF
--- a/docs/adr/0007-route-module-thin-api-layer.md
+++ b/docs/adr/0007-route-module-thin-api-layer.md
@@ -18,20 +18,22 @@ Endpoints in `backend/app/api/` are written with a `Route` decorator family — 
 
 The original decision said "audit by default" but did not pin what audit looks like. Pinning it here so every `Route`-decorated endpoint emits a uniform shape and downstream tooling (log search, dashboards) can rely on it.
 
+**Format: `key=value` fields concatenated into the log message string.** Not `extra={...}` — Python's stdlib logger silently drops `extra` keys unless the formatter is explicitly configured to render them, and the project ships with the default formatter by design (no JSON / structlog handler). The `_log_browse_telemetry` helper introduced in #59 is the reference pattern; PR-B adds a parallel `_log_audit` helper. A single `key=value` parser handles both telemetry channels.
+
 **Non-streaming routes — one line per request, emitted on close:**
 
 ```
-logger.info("audit", extra={"user": ..., "route": ..., "status_code": ..., "duration_ms": ...})
+audit user={user} route={route} status_code={status} duration_ms={ms}
 ```
 
-Same four-field shape as the `/files/browse*` telemetry shipped in #59 so a single log parser handles both. No new sink, no DB-backed audit table.
+No new sink, no DB-backed audit table.
 
 **Streaming routes (`route.stream`) — two lines per stream sharing a `stream_id`:**
 
 - **Open** (when the response stream is acquired):
-  `logger.info("audit.stream.open", extra={"stream_id": ..., "user": ..., "route": ..., "started_at": ...})`
+  `audit.stream.open stream_id={id} user={user} route={route} started_at={ts}`
 - **Close** (on completion, abort, or error):
-  `logger.info("audit.stream.close", extra={"stream_id": ..., "outcome": "completed" | "aborted" | "error", "duration_ms": ..., "error_class": ...})`
+  `audit.stream.close stream_id={id} outcome={completed|aborted|error} duration_ms={ms} [error_class={cls}]`
 
 Why two lines instead of one:
 - The single before/after model that `Route` uses for non-streaming requests cannot fire "after" — for SSE the response begins immediately and ends an unbounded time later. Logging only on open loses outcome; logging only on close loses the start signal that a stream existed at all (important for orphan detection if the worker dies mid-stream).


### PR DESCRIPTION
Follow-up to #62. Real bug, not a wording nit.

## What was wrong

The addendum specified:

```python
logger.info(\"audit\", extra={\"user\": ..., \"route\": ..., \"status_code\": ..., \"duration_ms\": ...})
```

Python's stdlib logger only renders \`extra={...}\` fields if the formatter is explicitly configured to read them. The project ships with the default formatter (no JSON / structlog handler) by design, so the spec as written would have produced audit lines like:

```
INFO:     app.audit - audit
```

— literally just the word \"audit\", with the user / route / status / duration silently dropped.

## What this changes

Specifies the wire format directly instead of a Python idiom. Same fields, but rendered as `key=value` concatenated into the log message:

```
audit user={user} route={route} status_code={status} duration_ms={ms}
```

Matches #59's `_log_browse_telemetry` helper exactly, so a single `key=value` parser handles both telemetry channels. PR-B introduces a parallel `_log_audit` helper following the same shape.

## Why not switch the project to a JSON formatter

Would work but: (1) bigger PR-B scope, (2) splits the project's logging story into two formats (telemetry already uses key=value), (3) reversible — if we ever want JSON, a per-logger handler change keeps the spec's field set intact.

Refs #24, #62.