### PR TITLE
feat(api): Route Module with typed CRUD + stream decorators (#24 PR-B)

### DIFF
--- a/backend/app/api/_route.py
+++ b/backend/app/api/_route.py
@@ -1,0 +1,608 @@
+"""Typed Route decorators for thin API handlers per ADR-0007.
+
+`Route` wraps a FastAPI ``APIRouter`` and turns a Manager callable plus an
+HTTP verb into a registered endpoint. The Manager signature is the source of
+truth for what the route binds: path params come from the URL pattern, body
+fields are unpacked (or the whole body model passed through) when a body is
+declared, ``AsyncSession`` is wired to ``get_db``, and any remaining typed
+param becomes a query.
+
+Decoration-time validation (``inspect.signature``) fails fast on:
+
+- non-async Managers,
+- untyped params,
+- ``Request`` / ``Response`` / ``app`` params (Managers do not see FastAPI
+  primitives — that lives at the Route layer per ADR-0007),
+- path placeholders that have no matching Manager param.
+
+The decorator family also owns audit logging — one ``key=value`` line on
+close for non-streaming routes, an open/close pair sharing a ``stream_id``
+for ``route.stream`` (per the audit-shape addendum to ADR-0007).
+``DomainError`` raised inside a Manager propagates to the global handler
+registered by :mod:`app.errors`; routes do not catch.
+
+This module is the foundation only — it is not used by any production
+router yet. ``backend/app/api/sessions.py`` migrates onto it in #24 PR-C
+and proves the contract; sub-issues #31-#53 each migrate one file.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+import time
+import uuid
+from typing import Any, Awaitable, Callable, Type, get_type_hints
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db
+
+audit_log = logging.getLogger("app.audit")
+
+
+class RouteSignatureError(TypeError):
+    """Raised at decoration time when a Manager signature is invalid for Route."""
+
+
+# Plain type → dependency injector for known long-lived services. Kept
+# minimal in PR-B; extended as sub-issues need additional injections.
+_TYPE_TO_INJECTOR: dict[type, Callable[..., Any]] = {
+    AsyncSession: get_db,
+}
+
+
+# ---------------------------------------------------------------------------
+# Audit logging — see ADR-0007 audit-shape addendum
+# ---------------------------------------------------------------------------
+
+
+def _log_audit(*, user: str, route: str, status_code: int, duration_ms: int) -> None:
+    fields = [
+        f"user={user}",
+        f"route={route}",
+        f"status_code={status_code}",
+        f"duration_ms={duration_ms}",
+    ]
+    audit_log.info("audit %s", " ".join(fields))
+
+
+def _log_stream_open(*, stream_id: str, user: str, route: str, started_at: float) -> None:
+    fields = [
+        f"stream_id={stream_id}",
+        f"user={user}",
+        f"route={route}",
+        f"started_at={started_at:.3f}",
+    ]
+    audit_log.info("audit.stream.open %s", " ".join(fields))
+
+
+def _log_stream_close(
+    *,
+    stream_id: str,
+    outcome: str,
+    duration_ms: int,
+    error_class: str | None = None,
+) -> None:
+    fields = [
+        f"stream_id={stream_id}",
+        f"outcome={outcome}",
+        f"duration_ms={duration_ms}",
+    ]
+    if error_class:
+        fields.append(f"error_class={error_class}")
+    audit_log.info("audit.stream.close %s", " ".join(fields))
+
+
+def _resolve_user(request: Request) -> str:
+    """Best-effort caller identity for audit. Anonymous if unauthenticated."""
+    return getattr(request.state, "user", None) or "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# Signature validation
+# ---------------------------------------------------------------------------
+
+
+_PATH_PLACEHOLDER = re.compile(r"\{([^}:]+)(?::[^}]*)?\}")
+_FORBIDDEN_PARAM_NAMES = {"request", "response", "app"}
+_FORBIDDEN_PARAM_TYPES: tuple[type, ...] = (Request, Response)
+
+
+def _path_param_names(path: str) -> list[str]:
+    return _PATH_PLACEHOLDER.findall(path)
+
+
+class _Bindings:
+    """Resolved param-by-param plan for a Manager + (verb, path, body)."""
+
+    def __init__(self) -> None:
+        self.path: list[str] = []
+        self.deps: dict[str, type] = {}
+        self.body_fields: list[str] = []
+        self.body_param: str | None = None
+        self.queries: dict[str, inspect.Parameter] = {}
+
+
+def _validate_and_bind(
+    manager: Callable[..., Awaitable[Any]],
+    *,
+    path: str,
+    body: Type[BaseModel] | None,
+) -> _Bindings:
+    if not inspect.iscoroutinefunction(manager):
+        raise RouteSignatureError(
+            f"Manager `{manager.__qualname__}` must be `async def`."
+        )
+
+    try:
+        hints = get_type_hints(manager)
+    except Exception as exc:
+        raise RouteSignatureError(
+            f"Could not resolve type hints for `{manager.__qualname__}`: {exc}"
+        ) from exc
+
+    declared_path = _path_param_names(path)
+    body_field_set = set(body.model_fields.keys()) if body is not None else set()
+
+    plan = _Bindings()
+    sig = inspect.signature(manager)
+
+    for name, param in sig.parameters.items():
+        if name in _FORBIDDEN_PARAM_NAMES:
+            raise RouteSignatureError(
+                f"Manager `{manager.__qualname__}` has forbidden param `{name}` — "
+                "Route does not pass FastAPI primitives to Managers."
+            )
+        if name not in hints:
+            raise RouteSignatureError(
+                f"Manager `{manager.__qualname__}` param `{name}` is untyped."
+            )
+        ann = hints[name]
+        if isinstance(ann, type) and issubclass(ann, _FORBIDDEN_PARAM_TYPES):
+            raise RouteSignatureError(
+                f"Manager `{manager.__qualname__}` param `{name}: {ann.__name__}` — "
+                "Route does not pass FastAPI primitives to Managers."
+            )
+
+        # Body-as-whole-model: typed as a BaseModel subclass and matches the
+        # declared body parameter exactly.
+        if (
+            body is not None
+            and isinstance(ann, type)
+            and issubclass(ann, BaseModel)
+            and ann is body
+        ):
+            if plan.body_param is not None:
+                raise RouteSignatureError(
+                    f"Manager `{manager.__qualname__}` declares two body-typed params."
+                )
+            plan.body_param = name
+            continue
+
+        if name in declared_path:
+            plan.path.append(name)
+            continue
+
+        if name in body_field_set:
+            plan.body_fields.append(name)
+            continue
+
+        if isinstance(ann, type) and ann in _TYPE_TO_INJECTOR:
+            plan.deps[name] = ann
+            continue
+
+        plan.queries[name] = param
+
+    missing_path = set(declared_path) - set(plan.path)
+    if missing_path:
+        raise RouteSignatureError(
+            f"Path `{path}` declares placeholder(s) {sorted(missing_path)} but "
+            f"Manager `{manager.__qualname__}` has no matching param."
+        )
+
+    return plan
+
+
+# ---------------------------------------------------------------------------
+# Endpoint generation
+# ---------------------------------------------------------------------------
+
+
+def _build_endpoint(
+    manager: Callable[..., Awaitable[Any]],
+    plan: _Bindings,
+    body: Type[BaseModel] | None,
+    *,
+    success_status: int,
+    not_found_on_none: bool,
+    not_found_message: str,
+) -> Callable[..., Awaitable[Any]]:
+    """Synthesize the FastAPI endpoint that wires request → Manager call."""
+
+    sig = inspect.signature(manager)
+    hints = get_type_hints(manager)
+
+    async def endpoint(request: Request, **kwargs: Any) -> Any:
+        started = time.perf_counter()
+        status_code = success_status
+        try:
+            mgr_kwargs: dict[str, Any] = {}
+            for name in plan.path:
+                mgr_kwargs[name] = kwargs[name]
+            for name, _ in plan.deps.items():
+                mgr_kwargs[name] = kwargs[name]
+            for name, _ in plan.queries.items():
+                if name in kwargs:
+                    mgr_kwargs[name] = kwargs[name]
+            if plan.body_param is not None:
+                mgr_kwargs[plan.body_param] = kwargs["_body"]
+            elif plan.body_fields:
+                body_obj: BaseModel = kwargs["_body"]
+                for name in plan.body_fields:
+                    mgr_kwargs[name] = getattr(body_obj, name)
+
+            result = await manager(**mgr_kwargs)
+            if result is None and not_found_on_none:
+                from app.errors import NotFound  # local import: avoids cycle in tests
+                status_code = 404
+                raise NotFound(not_found_message)
+            return result
+        except Exception as exc:
+            status_code = getattr(exc, "status_code", 500)
+            raise
+        finally:
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            _log_audit(
+                user=_resolve_user(request),
+                route=f"{request.method} {request.url.path}",
+                status_code=status_code,
+                duration_ms=duration_ms,
+            )
+
+    parameters: list[inspect.Parameter] = [
+        inspect.Parameter(
+            "request",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=Request,
+        )
+    ]
+    for name in plan.path:
+        parameters.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=hints[name],
+            )
+        )
+    for name, ann in plan.deps.items():
+        injector = _TYPE_TO_INJECTOR[ann]
+        parameters.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=ann,
+                default=Depends(injector),
+            )
+        )
+    for name, original in plan.queries.items():
+        default = original.default if original.default is not inspect.Parameter.empty else inspect.Parameter.empty
+        parameters.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=hints[name],
+                default=default,
+            )
+        )
+    if body is not None:
+        parameters.append(
+            inspect.Parameter(
+                "_body",
+                inspect.Parameter.KEYWORD_ONLY,
+                annotation=body,
+            )
+        )
+
+    endpoint.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=parameters,
+        return_annotation=sig.return_annotation,
+    )
+    endpoint.__name__ = f"{manager.__name__}_endpoint"
+    endpoint.__qualname__ = endpoint.__name__
+    return endpoint
+
+
+# ---------------------------------------------------------------------------
+# Route class
+# ---------------------------------------------------------------------------
+
+
+class Route:
+    """Typed Route decorators for thin API handlers (ADR-0007).
+
+    Wrap any number of Manager callables into a FastAPI ``APIRouter`` exposed
+    via ``Route.api_router``. Use the verb-named methods for CRUD,
+    :meth:`custom` for hand-written handlers that still get audit + global
+    error mapping, and :meth:`stream` for SSE-style endpoints.
+    """
+
+    def __init__(self, prefix: str = "", tags: list[str] | None = None) -> None:
+        self.api_router = APIRouter(prefix=prefix, tags=tags or [])
+
+    # CRUD ------------------------------------------------------------------
+
+    def list(
+        self,
+        path: str,
+        *,
+        manager: Callable[..., Awaitable[Any]],
+        response_model: Any = None,
+    ) -> None:
+        self._register("GET", path, manager, response_model=response_model)
+
+    def get(
+        self,
+        path: str,
+        *,
+        manager: Callable[..., Awaitable[Any]],
+        response_model: Any = None,
+        not_found_on_none: bool = False,
+        not_found_message: str = "Not found",
+    ) -> None:
+        self._register(
+            "GET",
+            path,
+            manager,
+            response_model=response_model,
+            not_found_on_none=not_found_on_none,
+            not_found_message=not_found_message,
+        )
+
+    def create(
+        self,
+        path: str,
+        *,
+        manager: Callable[..., Awaitable[Any]],
+        body: Type[BaseModel] | None = None,
+        response_model: Any = None,
+        status_code: int = 201,
+    ) -> None:
+        self._register(
+            "POST",
+            path,
+            manager,
+            body=body,
+            response_model=response_model,
+            status_code=status_code,
+        )
+
+    def update(
+        self,
+        path: str,
+        *,
+        manager: Callable[..., Awaitable[Any]],
+        body: Type[BaseModel] | None = None,
+        response_model: Any = None,
+        not_found_on_none: bool = False,
+        not_found_message: str = "Not found",
+    ) -> None:
+        self._register(
+            "PATCH",
+            path,
+            manager,
+            body=body,
+            response_model=response_model,
+            not_found_on_none=not_found_on_none,
+            not_found_message=not_found_message,
+        )
+
+    def delete(
+        self,
+        path: str,
+        *,
+        manager: Callable[..., Awaitable[Any]],
+        response_model: Any = None,
+    ) -> None:
+        self._register("DELETE", path, manager, response_model=response_model)
+
+    # Escape hatches --------------------------------------------------------
+
+    def custom(
+        self,
+        method: str,
+        path: str,
+        *,
+        handler: Callable[..., Awaitable[Any]],
+        response_model: Any = None,
+        status_code: int = 200,
+    ) -> None:
+        """Register a hand-written async handler. Audit logged like CRUD;
+        signature validation is skipped (the handler may legitimately accept
+        Request, Response, etc.)."""
+        if not inspect.iscoroutinefunction(handler):
+            raise RouteSignatureError(
+                f"Custom handler `{handler.__qualname__}` must be `async def`."
+            )
+
+        wrapped = _wrap_with_audit(handler)
+        self.api_router.add_api_route(
+            path,
+            wrapped,
+            methods=[method.upper()],
+            response_model=response_model,
+            status_code=status_code,
+        )
+
+    def stream(
+        self,
+        path: str,
+        *,
+        handler: Callable[..., Awaitable[Any]],
+        method: str = "POST",
+        status_code: int = 200,
+    ) -> None:
+        """Register a streaming handler. Emits open + close audit lines
+        sharing a ``stream_id`` (passed to the handler as a kwarg)."""
+        if not inspect.iscoroutinefunction(handler):
+            raise RouteSignatureError(
+                f"Stream handler `{handler.__qualname__}` must be `async def`."
+            )
+
+        wrapped = _wrap_with_stream_audit(handler)
+        self.api_router.add_api_route(
+            path,
+            wrapped,
+            methods=[method.upper()],
+            status_code=status_code,
+        )
+
+    # Internal --------------------------------------------------------------
+
+    def _register(
+        self,
+        method: str,
+        path: str,
+        manager: Callable[..., Awaitable[Any]],
+        *,
+        body: Type[BaseModel] | None = None,
+        response_model: Any = None,
+        status_code: int = 200,
+        not_found_on_none: bool = False,
+        not_found_message: str = "Not found",
+    ) -> None:
+        plan = _validate_and_bind(manager, path=path, body=body)
+        endpoint = _build_endpoint(
+            manager,
+            plan,
+            body,
+            success_status=status_code,
+            not_found_on_none=not_found_on_none,
+            not_found_message=not_found_message,
+        )
+        self.api_router.add_api_route(
+            path,
+            endpoint,
+            methods=[method.upper()],
+            response_model=response_model,
+            status_code=status_code,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Custom / stream wrappers
+# ---------------------------------------------------------------------------
+
+
+def _wrap_with_audit(handler: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+    """Wrap a hand-written async handler with one audit line on close."""
+
+    sig = inspect.signature(handler)
+    has_request = any(
+        p.annotation is Request or n == "request" for n, p in sig.parameters.items()
+    )
+
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        request: Request | None = kwargs.get("request") if has_request else None
+        if request is None:
+            for arg in list(args) + list(kwargs.values()):
+                if isinstance(arg, Request):
+                    request = arg
+                    break
+
+        started = time.perf_counter()
+        status_code = 200
+        try:
+            return await handler(*args, **kwargs)
+        except Exception as exc:
+            status_code = getattr(exc, "status_code", 500)
+            raise
+        finally:
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            _log_audit(
+                user=_resolve_user(request) if request is not None else "anonymous",
+                route=(
+                    f"{request.method} {request.url.path}"
+                    if request is not None
+                    else "custom"
+                ),
+                status_code=status_code,
+                duration_ms=duration_ms,
+            )
+
+    wrapped.__signature__ = sig  # type: ignore[attr-defined]
+    wrapped.__name__ = f"{handler.__name__}_audited"
+    wrapped.__qualname__ = wrapped.__name__
+    return wrapped
+
+
+def _wrap_with_stream_audit(
+    handler: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]:
+    """Wrap a streaming handler with open + close audit lines.
+
+    The handler must take a keyword argument ``stream_id: str`` — Route
+    generates a fresh id per request and propagates it so the close line
+    can be correlated to the open line. The handler's job is to return the
+    streaming response; lifecycle bookkeeping lives here.
+    """
+
+    original_sig = inspect.signature(handler)
+    if "stream_id" not in original_sig.parameters:
+        raise RouteSignatureError(
+            f"Stream handler `{handler.__qualname__}` must accept a "
+            "`stream_id: str` keyword argument."
+        )
+
+    # Strip stream_id from FastAPI's view of the handler signature — it is
+    # synthesised by Route, not extracted from the request.
+    public_params = [p for n, p in original_sig.parameters.items() if n != "stream_id"]
+    public_sig = original_sig.replace(parameters=public_params)
+
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        request: Request | None = kwargs.get("request")
+        if request is None:
+            for arg in list(args) + list(kwargs.values()):
+                if isinstance(arg, Request):
+                    request = arg
+                    break
+
+        stream_id = uuid.uuid4().hex
+        started_at = time.time()
+        started_perf = time.perf_counter()
+
+        _log_stream_open(
+            stream_id=stream_id,
+            user=_resolve_user(request) if request is not None else "anonymous",
+            route=(
+                f"{request.method} {request.url.path}"
+                if request is not None
+                else "stream"
+            ),
+            started_at=started_at,
+        )
+
+        outcome = "completed"
+        error_class: str | None = None
+        try:
+            return await handler(*args, stream_id=stream_id, **kwargs)
+        except Exception as exc:
+            outcome = "error"
+            error_class = type(exc).__name__
+            raise
+        finally:
+            duration_ms = int((time.perf_counter() - started_perf) * 1000)
+            _log_stream_close(
+                stream_id=stream_id,
+                outcome=outcome,
+                duration_ms=duration_ms,
+                error_class=error_class,
+            )
+
+    wrapped.__signature__ = public_sig  # type: ignore[attr-defined]
+    wrapped.__name__ = f"{handler.__name__}_streamed"
+    wrapped.__qualname__ = wrapped.__name__
+    return wrapped

--- a/backend/tests/test_api/test_route.py
+++ b/backend/tests/test_api/test_route.py
@@ -1,0 +1,350 @@
+"""Tests for the Route Module (app.api._route).
+
+PR-B foundation tests — the Route class itself is exercised here; production
+routers continue to use plain FastAPI APIRouter until PR-C migrates
+sessions.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+from app.api._route import Route, RouteSignatureError, _validate_and_bind
+from app.errors import Conflict, NotFound, register_error_handlers
+
+
+# ---------------------------------------------------------------------------
+# Signature validation
+# ---------------------------------------------------------------------------
+
+
+def test_validation_rejects_sync_manager():
+    def sync_manager(item_id: str) -> str:
+        return item_id
+
+    with pytest.raises(RouteSignatureError, match="must be `async def`"):
+        _validate_and_bind(sync_manager, path="/items/{item_id}", body=None)
+
+
+def test_validation_rejects_untyped_param():
+    async def bad(item_id) -> str:  # noqa: ANN001
+        return item_id
+
+    with pytest.raises(RouteSignatureError, match="untyped"):
+        _validate_and_bind(bad, path="/items/{item_id}", body=None)
+
+
+def test_validation_rejects_forbidden_param_name():
+    async def bad(request: str) -> str:
+        return request
+
+    with pytest.raises(RouteSignatureError, match="forbidden param"):
+        _validate_and_bind(bad, path="/items", body=None)
+
+
+def test_validation_rejects_request_typed_param():
+    async def bad(req: Request) -> str:
+        return "x"
+
+    with pytest.raises(RouteSignatureError, match="FastAPI primitives"):
+        _validate_and_bind(bad, path="/items", body=None)
+
+
+def test_validation_rejects_path_placeholder_without_param():
+    async def bad(other: str) -> str:
+        return other
+
+    with pytest.raises(RouteSignatureError, match="placeholder"):
+        _validate_and_bind(bad, path="/items/{item_id}", body=None)
+
+
+def test_validation_accepts_typed_path_only_manager():
+    async def good(item_id: str) -> str:
+        return item_id
+
+    plan = _validate_and_bind(good, path="/items/{item_id}", body=None)
+    assert plan.path == ["item_id"]
+    assert plan.deps == {}
+    assert plan.queries == {}
+    assert plan.body_param is None
+    assert plan.body_fields == []
+
+
+# ---------------------------------------------------------------------------
+# Test app — mounts a Route router for end-to-end dispatch tests
+# ---------------------------------------------------------------------------
+
+
+_STORE: dict[str, dict] = {}
+
+
+class ItemCreate(BaseModel):
+    name: str
+    quantity: int
+
+
+class Item(BaseModel):
+    id: str
+    name: str
+    quantity: int
+
+
+# Manager free functions — these would live in `app/<domain>/manager.py` in
+# production. They take only the data they need; no FastAPI primitives.
+
+
+async def list_items(limit: int = 10) -> list[Item]:
+    return list(_STORE.values())[:limit]
+
+
+async def get_item(item_id: str) -> Item | None:
+    raw = _STORE.get(item_id)
+    return Item(**raw) if raw else None
+
+
+async def create_item(name: str, quantity: int) -> Item:
+    item_id = f"item-{len(_STORE) + 1}"
+    item = {"id": item_id, "name": name, "quantity": quantity}
+    _STORE[item_id] = item
+    return Item(**item)
+
+
+async def create_item_via_model(body: ItemCreate) -> Item:
+    return await create_item(name=body.name, quantity=body.quantity)
+
+
+async def update_item(item_id: str, name: str, quantity: int) -> Item | None:
+    if item_id not in _STORE:
+        return None
+    _STORE[item_id]["name"] = name
+    _STORE[item_id]["quantity"] = quantity
+    return Item(**_STORE[item_id])
+
+
+async def delete_item(item_id: str) -> dict:
+    if item_id not in _STORE:
+        raise NotFound("item missing")
+    del _STORE[item_id]
+    return {"deleted": True}
+
+
+def _build_app() -> FastAPI:
+    _STORE.clear()
+    app = FastAPI()
+    register_error_handlers(app)
+
+    route = Route(prefix="/items", tags=["items"])
+    route.list("", manager=list_items, response_model=list[Item])
+    route.get(
+        "/{item_id}",
+        manager=get_item,
+        response_model=Item,
+        not_found_on_none=True,
+        not_found_message="item missing",
+    )
+    route.create("", manager=create_item, body=ItemCreate, response_model=Item)
+    route.update(
+        "/{item_id}",
+        manager=update_item,
+        body=ItemCreate,
+        response_model=Item,
+        not_found_on_none=True,
+        not_found_message="item missing",
+    )
+    route.delete("/{item_id}", manager=delete_item)
+
+    other = Route(prefix="/items-via-model", tags=["items"])
+    other.create(
+        "",
+        manager=create_item_via_model,
+        body=ItemCreate,
+        response_model=Item,
+    )
+
+    app.include_router(route.api_router)
+    app.include_router(other.api_router)
+    return app
+
+
+@pytest.fixture
+async def client():
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# CRUD dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_then_create_then_get(client):
+    assert (await client.get("/items")).json() == []
+
+    resp = await client.post("/items", json={"name": "widget", "quantity": 3})
+    assert resp.status_code == 201
+    created = resp.json()
+    assert created["name"] == "widget"
+    assert created["quantity"] == 3
+
+    item_id = created["id"]
+    fetched = await client.get(f"/items/{item_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == item_id
+
+
+@pytest.mark.asyncio
+async def test_get_returns_404_when_manager_returns_none(client):
+    resp = await client.get("/items/missing")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "item missing", "code": "not_found"}
+
+
+@pytest.mark.asyncio
+async def test_update_changes_state(client):
+    await client.post("/items", json={"name": "a", "quantity": 1})
+    resp = await client.patch("/items/item-1", json={"name": "b", "quantity": 7})
+    assert resp.status_code == 200
+    assert resp.json()["quantity"] == 7
+
+
+@pytest.mark.asyncio
+async def test_update_returns_404_on_missing(client):
+    resp = await client.patch("/items/nope", json={"name": "x", "quantity": 1})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_propagates_domain_error(client):
+    resp = await client.delete("/items/nope")
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_query_param_dispatch(client):
+    for i in range(5):
+        await client.post("/items", json={"name": f"x{i}", "quantity": i})
+    resp = await client.get("/items?limit=3")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+
+@pytest.mark.asyncio
+async def test_body_passed_as_whole_model(client):
+    resp = await client.post("/items-via-model", json={"name": "z", "quantity": 9})
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "z"
+
+
+# ---------------------------------------------------------------------------
+# Audit logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_emits_one_line_per_request(client, caplog):
+    with caplog.at_level(logging.INFO, logger="app.audit"):
+        await client.post("/items", json={"name": "a", "quantity": 1})
+
+    audit_records = [r for r in caplog.records if r.message.startswith("audit ")]
+    assert len(audit_records) == 1
+    msg = audit_records[0].message
+    assert "user=anonymous" in msg
+    assert "route=POST /items" in msg
+    assert "status_code=201" in msg
+    assert "duration_ms=" in msg
+
+
+@pytest.mark.asyncio
+async def test_audit_records_4xx_status(client, caplog):
+    with caplog.at_level(logging.INFO, logger="app.audit"):
+        await client.get("/items/missing")
+
+    audit_records = [r for r in caplog.records if r.message.startswith("audit ")]
+    assert len(audit_records) == 1
+    assert "status_code=404" in audit_records[0].message
+
+
+# ---------------------------------------------------------------------------
+# Stream — open + close audit lines with shared stream_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_open_then_close(caplog):
+    from fastapi.responses import StreamingResponse
+
+    app = FastAPI()
+    register_error_handlers(app)
+    route = Route(prefix="/s")
+
+    async def echo_stream(stream_id: str, request: Request) -> StreamingResponse:
+        async def gen():
+            yield f"id={stream_id}\n".encode()
+            yield b"chunk\n"
+
+        return StreamingResponse(gen(), media_type="text/plain")
+
+    route.stream("/echo", handler=echo_stream, method="GET")
+    app.include_router(route.api_router)
+
+    transport = httpx.ASGITransport(app=app)
+    with caplog.at_level(logging.INFO, logger="app.audit"):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/s/echo")
+            assert resp.status_code == 200
+            assert b"chunk" in resp.content
+
+    open_recs = [r for r in caplog.records if r.message.startswith("audit.stream.open")]
+    close_recs = [r for r in caplog.records if r.message.startswith("audit.stream.close")]
+    assert len(open_recs) == 1
+    assert len(close_recs) == 1
+
+    open_msg = open_recs[0].message
+    close_msg = close_recs[0].message
+    open_id = next(p.split("=")[1] for p in open_msg.split() if p.startswith("stream_id="))
+    close_id = next(p.split("=")[1] for p in close_msg.split() if p.startswith("stream_id="))
+    assert open_id == close_id
+    assert "outcome=completed" in close_msg
+
+
+@pytest.mark.asyncio
+async def test_stream_close_records_error(caplog):
+    app = FastAPI()
+    register_error_handlers(app)
+    route = Route(prefix="/s")
+
+    async def boom(stream_id: str, request: Request):
+        raise Conflict("nope")
+
+    route.stream("/boom", handler=boom, method="GET")
+    app.include_router(route.api_router)
+
+    transport = httpx.ASGITransport(app=app)
+    with caplog.at_level(logging.INFO, logger="app.audit"):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/s/boom")
+            assert resp.status_code == 409
+
+    close_recs = [r for r in caplog.records if r.message.startswith("audit.stream.close")]
+    assert len(close_recs) == 1
+    assert "outcome=error" in close_recs[0].message
+    assert "error_class=Conflict" in close_recs[0].message
+
+
+def test_stream_handler_must_accept_stream_id():
+    route = Route()
+
+    async def no_stream_id(request: Request):
+        return None
+
+    with pytest.raises(RouteSignatureError, match="stream_id"):
+        route.stream("/x", handler=no_stream_id, method="GET")


### PR DESCRIPTION
Foundation for #24 PR-C and the 23 follow-up API sub-issues (#31-#53). Sits between #61 (DomainError, merged) and #62/#63 (audit-shape ADR + format fix). Migrates **no production routes** — that's PR-C — but the dispatch is real and tested end-to-end via `httpx`, so PR-C can adopt with confidence.

## What `Route` does

A thin wrapper around FastAPI's `APIRouter`. You give it a Manager callable and an HTTP verb; it inspects the Manager's signature, validates it, and synthesises the FastAPI endpoint that binds path / body / deps / queries to Manager kwargs.

```python
route = Route(prefix=\"/items\", tags=[\"items\"])
route.list(\"\", manager=list_items, response_model=list[Item])
route.get(\"/{item_id}\", manager=get_item, response_model=Item, not_found_on_none=True)
route.create(\"\", manager=create_item, body=ItemCreate, response_model=Item)
route.update(\"/{item_id}\", manager=update_item, body=ItemCreate, response_model=Item)
route.delete(\"/{item_id}\", manager=delete_item)
app.include_router(route.api_router)
```

## Signature validation (decoration-time, fail-fast)

`RouteSignatureError` raised on:
- non-async Manager
- untyped params
- `Request` / `Response` / `app` params (Managers don't see FastAPI primitives)
- path placeholders that have no matching Manager param

## Body binding — two shapes supported

1. **Whole body model**: Manager declares `body: ItemCreate` → passed through.
2. **Field unpacking**: Manager declares `name: str, quantity: int` matching the body model's fields → unpacked into kwargs.

This is deliberate flexibility for PR-C — sessions.py's existing managers (`create_session(db, project_id, directory, title)`) take individual fields, so field unpacking lets them migrate without a manager-side refactor first. New managers can adopt the cleaner whole-model shape.

## Escape hatches

- `route.custom(method, path, handler=...)` — hand-written async handler, gets audit + global error mapping for free, signature is *not* validated (the handler may legitimately accept Request).
- `route.stream(path, handler=...)` — handler must accept `stream_id: str` kwarg; Route generates the id and propagates it. Two audit lines per stream, sharing the id.

## Audit logging

Per ADR-0007's audit-shape addendum (#62) and the format fix (#63):

- **Non-stream**: `audit user=... route=... status_code=... duration_ms=...`
- **Stream open**: `audit.stream.open stream_id=... user=... route=... started_at=...`
- **Stream close**: `audit.stream.close stream_id=... outcome=completed|error duration_ms=... [error_class=...]`

`key=value` strings concatenated into the message — **not** `extra={}` which the default formatter silently drops. Matches `_log_browse_telemetry`'s shape from #59 so a single parser handles both telemetry channels.

## Out of scope (deferred)

- `multipart` decorator — no consumer in PR-C; one-adapter rule says wait until #32 (files.py uploads).
- `TestRouteRegistry` — split out as #60 to keep PR-B's surface tight.
- Service-dep injectors beyond `AsyncSession` — added per sub-issue as Managers need them. The `_TYPE_TO_INJECTOR` table makes this a one-line extension.

## Verification

- 18 new tests in `tests/test_api/test_route.py`: validation matrix, end-to-end CRUD dispatch via `httpx.ASGITransport`, audit emission for non-stream and stream paths, DomainError propagation through the Route layer.
- Full suite: **758 passed / 20 skipped** (pre-existing). Baseline before PR-B was 740, so +18 net (matches the new tests; no regressions).

## Rebase note

This branch is independent of #63 (which only touches `docs/adr/`). #63's ADR fix establishes that the actual audit format is `key=value` not `extra={}` — this PR already implements `key=value`, so no follow-up needed when #63 lands.

Refs #24, ADR-0007.