### PR TITLE
refactor(api): migrate sessions.py onto Route Module (#24 PR-C)

### DIFF
--- a/backend/app/api/_route.py
+++ b/backend/app/api/_route.py
@@ -40,6 +40,7 @@ from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_db
+from app.errors import NotFound
 
 audit_log = logging.getLogger("app.audit")
 
@@ -98,8 +99,16 @@ def _log_stream_close(
 
 
 def _resolve_user(request: Request) -> str:
-    """Best-effort caller identity for audit. Anonymous if unauthenticated."""
-    return getattr(request.state, "user", None) or "anonymous"
+    """Best-effort caller identity for audit.
+
+    Contract: ``AuthMiddleware`` sets ``request.state.user`` to a ``str | None``
+    user-id (or leaves it unset for unauthenticated requests). The ``str()``
+    coercion defends against future drift — if the value ever becomes a
+    ``User`` object or dict, an unconverted value would render as
+    ``user={'id': ...}`` and silently break the ``key=value`` audit parser.
+    """
+    raw = getattr(request.state, "user", None)
+    return str(raw) if raw else "anonymous"
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +117,7 @@ def _resolve_user(request: Request) -> str:
 
 
 _PATH_PLACEHOLDER = re.compile(r"\{([^}:]+)(?::[^}]*)?\}")
-_FORBIDDEN_PARAM_NAMES = {"request", "response", "app"}
+_FORBIDDEN_PARAM_NAMES = {"request", "response", "app", "_body"}
 _FORBIDDEN_PARAM_TYPES: tuple[type, ...] = (Request, Response)
 
 
@@ -168,14 +177,23 @@ def _validate_and_bind(
                 "Route does not pass FastAPI primitives to Managers."
             )
 
-        # Body-as-whole-model: typed as a BaseModel subclass and matches the
-        # declared body parameter exactly.
-        if (
-            body is not None
-            and isinstance(ann, type)
-            and issubclass(ann, BaseModel)
-            and ann is body
-        ):
+        # Body-as-whole-model: typed as a BaseModel subclass. Must match the
+        # declared body, otherwise FastAPI would later try to resolve the
+        # mismatched model from query params and surface a confusing error
+        # far from the cause — fail fast at decoration time instead.
+        if isinstance(ann, type) and issubclass(ann, BaseModel):
+            if body is None:
+                raise RouteSignatureError(
+                    f"Manager `{manager.__qualname__}` param "
+                    f"`{name}: {ann.__name__}` is a BaseModel but the route "
+                    "declares no `body=...`."
+                )
+            if ann is not body:
+                raise RouteSignatureError(
+                    f"Manager `{manager.__qualname__}` param "
+                    f"`{name}: {ann.__name__}` does not match the declared "
+                    f"body `{body.__name__}`."
+                )
             if plan.body_param is not None:
                 raise RouteSignatureError(
                     f"Manager `{manager.__qualname__}` declares two body-typed params."
@@ -247,14 +265,19 @@ def _build_endpoint(
 
             result = await manager(**mgr_kwargs)
             if result is None and not_found_on_none:
-                from app.errors import NotFound  # local import: avoids cycle in tests
-                status_code = 404
                 raise NotFound(not_found_message)
             return result
         except Exception as exc:
             status_code = getattr(exc, "status_code", 500)
             raise
         finally:
+            # Audit reflects the Manager's outcome. If response_model
+            # serialization fails downstream of this `finally` (e.g. the
+            # Manager returned a value the schema can't validate), the
+            # audit line records status=success while the client receives
+            # 500. That matches the "Manager succeeded; failure was at the
+            # boundary" reading; dashboards consuming audit should treat
+            # 500s in error-handler logs as the authoritative count.
             duration_ms = int((time.perf_counter() - started) * 1000)
             _log_audit(
                 user=_resolve_user(request),
@@ -289,7 +312,7 @@ def _build_endpoint(
             )
         )
     for name, original in plan.queries.items():
-        default = original.default if original.default is not inspect.Parameter.empty else inspect.Parameter.empty
+        default = original.default
         parameters.append(
             inspect.Parameter(
                 name,

--- a/backend/app/api/_route.py
+++ b/backend/app/api/_route.py
@@ -32,15 +32,25 @@ import inspect
 import logging
 import re
 import time
+import typing
 import uuid
 from typing import Any, Awaitable, Callable, Type, get_type_hints
 
 from fastapi import APIRouter, Depends, Request, Response
 from pydantic import BaseModel
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.dependencies import get_db
+from app.agent.agent import AgentRegistry
+from app.dependencies import (
+    get_agent_registry,
+    get_db,
+    get_provider_registry,
+    get_session_factory,
+    get_stream_manager,
+)
 from app.errors import NotFound
+from app.provider.registry import ProviderRegistry
+from app.streaming.manager import StreamManager
 
 audit_log = logging.getLogger("app.audit")
 
@@ -49,11 +59,33 @@ class RouteSignatureError(TypeError):
     """Raised at decoration time when a Manager signature is invalid for Route."""
 
 
-# Plain type → dependency injector for known long-lived services. Kept
-# minimal in PR-B; extended as sub-issues need additional injections.
+# Plain type → dependency injector for known long-lived services. Generic
+# aliases (e.g. ``async_sessionmaker[AsyncSession]``) are matched via
+# ``typing.get_origin`` so callers can keep their natural type annotations.
+# Each entry is added when a sub-issue's Manager calls for it; do not add
+# entries speculatively (one-adapter rule).
 _TYPE_TO_INJECTOR: dict[type, Callable[..., Any]] = {
     AsyncSession: get_db,
+    StreamManager: get_stream_manager,
+    ProviderRegistry: get_provider_registry,
+    AgentRegistry: get_agent_registry,
+    async_sessionmaker: get_session_factory,
 }
+
+
+def _resolve_injector(ann: Any) -> Callable[..., Any] | None:
+    """Map a type annotation to its dependency injector, if any.
+
+    Handles plain classes (``AsyncSession``) and generic aliases
+    (``async_sessionmaker[AsyncSession]``) — both resolve to the same
+    injector since the request-time value is identical.
+    """
+    if isinstance(ann, type) and ann in _TYPE_TO_INJECTOR:
+        return _TYPE_TO_INJECTOR[ann]
+    origin = typing.get_origin(ann)
+    if origin is not None and origin in _TYPE_TO_INJECTOR:
+        return _TYPE_TO_INJECTOR[origin]
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +241,7 @@ def _validate_and_bind(
             plan.body_fields.append(name)
             continue
 
-        if isinstance(ann, type) and ann in _TYPE_TO_INJECTOR:
+        if _resolve_injector(ann) is not None:
             plan.deps[name] = ann
             continue
 
@@ -302,7 +334,7 @@ def _build_endpoint(
             )
         )
     for name, ann in plan.deps.items():
-        injector = _TYPE_TO_INJECTOR[ann]
+        injector = _resolve_injector(ann)
         parameters.append(
             inspect.Parameter(
                 name,

--- a/backend/app/api/sessions.py
+++ b/backend/app/api/sessions.py
@@ -1,4 +1,21 @@
-"""Session CRUD endpoints."""
+"""Session CRUD endpoints — wired through the Route Module (ADR-0007).
+
+The 11 endpoints split between:
+
+- ``Route``-decorated CRUD: ``list / get / create / update / delete`` for
+  ``/sessions`` and ``/sessions/{id}``, plus ``list`` for ``/sessions/search``.
+  These call into ``app/session/manager.py`` cascades — ``create_session_and_index``,
+  ``update_session``, ``delete_session_cascade`` — that own the multi-step
+  orchestration (FTS reindex on directory change, stream abort + uploads
+  cleanup on delete) per ADR-0007.
+- ``Route.custom``: the four endpoints that are not CRUD — todos / files /
+  compact / export-pdf / export-md. Each is a hand-written async handler
+  that gets audit logging and ``DomainError`` mapping for free; their
+  shapes (binary ``Response`` for exports, optional body for compact,
+  in-line file-system probing for files) don't fit the typed-Manager
+  contract and pretending otherwise would invent more decorator surface
+  than warranted.
+"""
 
 from __future__ import annotations
 
@@ -7,43 +24,43 @@ import re
 from datetime import datetime, timezone
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import Depends, Request
 from fastapi.responses import Response
-from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm.attributes import flag_modified
 
+from app.api._route import Route
 from app.api.pdf import markdown_to_pdf
-from app.errors import Conflict, DomainError, InternalError, NotFound, UpstreamError
 from app.dependencies import (
     AgentRegistryDep,
     ProviderRegistryDep,
     SessionFactoryDep,
     StreamManagerDep,
     get_db,
-    get_index_manager,
+    get_session_factory,
 )
-from app.models.session import Session
+from app.errors import DomainError, InternalError, NotFound
 from app.models.session_file import SessionFile
-from app.schemas.session import SessionCreate, SessionResponse, SessionSearchResult, SessionUpdate
-from app.session.compaction import run_compaction
+from app.schemas.session import (
+    SessionCompactionRequest,
+    SessionCreate,
+    SessionResponse,
+    SessionSearchResult,
+    SessionUpdate,
+)
 from app.session.manager import (
-    create_session,
-    delete_session_uploads,
+    compact_session_cascade,
+    create_session_and_index,
+    delete_session_cascade,
     get_messages,
     get_session,
     list_sessions,
     search_sessions,
-    update_session_title,
+    update_session,
 )
-from app.storage.repository import delete_by_id
-from app.streaming.manager import GenerationJob
-from app.utils.id import generate_ulid
 
 log = logging.getLogger(__name__)
 
-router = APIRouter()
 _PATH_PATTERN = re.compile(r"(/[^\s`]+?\.[A-Za-z0-9]{1,10})")
 _CREATION_HINT_PATTERN = re.compile(
     r"\b(created?|written|saved|generated|exported|output)\b",
@@ -58,30 +75,87 @@ _BULLET_FILENAME_PATTERN = re.compile(
 )
 
 
-class SessionCompactionRequest(BaseModel):
-    model_id: str | None = None
+# ---------------------------------------------------------------------------
+# Route registrations — order matters for FastAPI: more specific paths
+# (`/sessions/search`) must register before parameterised ones
+# (`/sessions/{session_id}`) so the literal route wins.
+# ---------------------------------------------------------------------------
+
+route = Route(tags=["sessions"])
+
+route.list(
+    "/sessions",
+    manager=list_sessions,
+    response_model=list[SessionResponse],
+)
+
+route.list(
+    "/sessions/search",
+    manager=search_sessions,
+    response_model=list[SessionSearchResult],
+)
+
+route.create(
+    "/sessions",
+    manager=create_session_and_index,
+    body=SessionCreate,
+    response_model=SessionResponse,
+    status_code=201,
+)
+
+route.get(
+    "/sessions/{session_id}",
+    manager=get_session,
+    response_model=SessionResponse,
+    not_found_on_none=True,
+    not_found_message="Session not found",
+)
+
+route.update(
+    "/sessions/{session_id}",
+    manager=update_session,
+    body=SessionUpdate,
+    response_model=SessionResponse,
+)
+
+route.delete(
+    "/sessions/{session_id}",
+    manager=delete_session_cascade,
+)
 
 
-def _trigger_index(request: Request, directory: str | None, session_id: str | None = None) -> None:
-    """Fire-and-forget: start FTS indexing for *directory* if enabled."""
-    if not directory or not session_id:
-        return
-    manager = getattr(request.app.state, "index_manager", None)
-    if manager is None:
-        return
-    import asyncio
-    asyncio.create_task(
-        manager.ensure_index(directory, session_id),
-        name=f"fts-trigger-{session_id[:12]}",
-    )
+# ---------------------------------------------------------------------------
+# Hand-written custom handlers — non-CRUD shapes
+# ---------------------------------------------------------------------------
 
 
-def _extract_file_paths_from_messages(messages: list, session_directory: str | None) -> list[str]:
-    """Best-effort recovery of files that were created during older sessions.
+async def _list_session_todos(
+    session_id: str,
+    request: Request,
+) -> dict:
+    """Return the in-memory todo list for ``session_id``.
 
-    This is intentionally conservative: it should recover explicit creation
-    outputs from older code_execute-style sessions, but it must not treat files
-    merely *read* during analysis as generated workspace files.
+    ``get_todos`` reads from a side-channel keyed off ``session_id`` rather
+    than the DB, so we pass through to the existing helper.
+    """
+    from app.tool.builtin.todo import get_todos
+
+    session_factory = get_session_factory()
+    if session_factory is None:
+        return {"todos": []}
+    todos = await get_todos(session_id, session_factory)
+    return {"todos": todos}
+
+
+def _extract_file_paths_from_messages(
+    messages: list,
+    session_directory: str | None,
+) -> list[str]:
+    """Best-effort recovery of files created during older sessions.
+
+    Conservative: recovers explicit creation outputs from ``code_execute``-
+    style sessions but does not treat files merely *read* during analysis
+    as generated workspace files.
     """
     if not session_directory:
         return []
@@ -108,7 +182,6 @@ def _extract_file_paths_from_messages(messages: list, session_directory: str | N
             else:
                 continue
 
-            # Case 1: direct absolute paths in explicit creation/writing context.
             for raw_match in _PATH_PATTERN.findall(payload):
                 candidate = str(Path(raw_match).resolve())
                 if not Path(candidate).is_file():
@@ -120,8 +193,6 @@ def _extract_file_paths_from_messages(messages: list, session_directory: str | N
                 seen.add(candidate)
                 found.append(candidate)
 
-            # Case 2: assistant summaries like:
-            # "Created in /path/to/dir:" + bullet list of filenames
             created_in_match = _CREATED_IN_PATTERN.search(payload)
             if created_in_match:
                 target_dir = str(Path(created_in_match.group(1)).resolve())
@@ -141,125 +212,12 @@ def _extract_file_paths_from_messages(messages: list, session_directory: str | N
     return found
 
 
-@router.get("/sessions", response_model=list[SessionResponse])
-async def list_sessions_endpoint(
-    db: AsyncSession = Depends(get_db),
-    limit: int = 50,
-    offset: int = 0,
-    project_id: str | None = None,
-) -> list[SessionResponse]:
-    """List sessions."""
-    sessions = await list_sessions(db, limit=limit, offset=offset, project_id=project_id)
-    return [SessionResponse.model_validate(s) for s in sessions]
-
-
-@router.get("/sessions/search", response_model=list[SessionSearchResult])
-async def search_sessions_endpoint(
-    q: str,
-    db: AsyncSession = Depends(get_db),
-    limit: int = 20,
-    offset: int = 0,
-) -> list[SessionSearchResult]:
-    """Search sessions by title and message content."""
-    if not q.strip():
-        return []
-    results = await search_sessions(db, q.strip(), limit=limit, offset=offset)
-    return [
-        SessionSearchResult(
-            session=SessionResponse.model_validate(r["session"]),
-            snippet=r["snippet"],
-        )
-        for r in results
-    ]
-
-
-@router.post("/sessions", response_model=SessionResponse, status_code=201)
-async def create_session_endpoint(
-    request: Request,
-    body: SessionCreate,
-    db: AsyncSession = Depends(get_db),
-) -> SessionResponse:
-    """Create a new session."""
-    session = await create_session(
-        db,
-        project_id=body.project_id,
-        directory=body.directory,
-        title=body.title,
-    )
-    _trigger_index(request, body.directory, session.id)
-    return SessionResponse.model_validate(session)
-
-
-@router.get("/sessions/{session_id}", response_model=SessionResponse)
-async def get_session_endpoint(
-    session_id: str,
-    db: AsyncSession = Depends(get_db),
-) -> SessionResponse:
-    """Get session details."""
-    session = await get_session(db, session_id)
-    if session is None:
-        raise NotFound("Session not found")
-    return SessionResponse.model_validate(session)
-
-
-@router.patch("/sessions/{session_id}", response_model=SessionResponse)
-async def update_session_endpoint(
-    request: Request,
-    session_id: str,
-    body: SessionUpdate,
-    db: AsyncSession = Depends(get_db),
-) -> SessionResponse:
-    """Update session fields."""
-    session = await get_session(db, session_id)
-    if session is None:
-        raise NotFound("Session not found")
-
-    original_time_updated = session.time_updated
-    metadata_only_fields = {"is_pinned", "time_archived"}
-    preserve_time_updated = bool(body.model_fields_set) and body.model_fields_set <= metadata_only_fields
-
-    if body.title is not None:
-        session.title = body.title
-    if body.directory is not None:
-        session.directory = body.directory
-        _trigger_index(request, body.directory, session_id)
-    if "time_archived" in body.model_fields_set:
-        session.time_archived = body.time_archived
-    if body.is_pinned is not None:
-        session.is_pinned = body.is_pinned
-    if body.permission is not None:
-        session.permission = body.permission
-    if preserve_time_updated:
-        session.time_updated = original_time_updated
-        flag_modified(session, "time_updated")
-
-    await db.flush()
-    await db.refresh(session)
-    return SessionResponse.model_validate(session)
-
-
-@router.get("/sessions/{session_id}/todos")
-async def get_session_todos(
+async def _list_session_files(
     session_id: str,
     request: Request,
-) -> dict:
-    """Get current todo list for a session."""
-    from app.tool.builtin.todo import get_todos
-
-    session_factory = getattr(request.app.state, "session_factory", None)
-    if session_factory is None:
-        return {"todos": []}
-    todos = await get_todos(session_id, session_factory)
-    return {"todos": todos}
-
-
-@router.get("/sessions/{session_id}/files")
-async def get_session_files(
-    session_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Get tracked workspace files for a session."""
-
+    """Return tracked workspace files for ``session_id``."""
     session = await get_session(db, session_id)
     if session is None or not session.directory:
         return {"files": []}
@@ -285,7 +243,6 @@ async def get_session_files(
             "tool": entry.tool_id,
         })
 
-    # Backward-compatible fallback for older sessions that were never tracked.
     output_dir = Path(session.directory).resolve() / "openyak_written"
     if output_dir.is_dir():
         for entry in sorted(output_dir.iterdir(), key=lambda e: e.stat().st_mtime):
@@ -300,9 +257,6 @@ async def get_session_files(
                 "tool": "artifact",
             })
 
-    # Legacy fallback for older code_execute-created files: recover paths from
-    # persisted tool outputs and assistant text when SessionFile tracking did
-    # not yet record them.
     if not files:
         messages = await get_messages(db, session_id, limit=500, offset=0)
         recovered_paths = _extract_file_paths_from_messages(messages, session.directory)
@@ -320,8 +274,7 @@ async def get_session_files(
     return {"files": files}
 
 
-@router.post("/sessions/{session_id}/compact")
-async def compact_session_endpoint(
+async def _compact_session(
     session_id: str,
     session_factory: SessionFactoryDep,
     provider_registry: ProviderRegistryDep,
@@ -330,96 +283,25 @@ async def compact_session_endpoint(
     db: AsyncSession = Depends(get_db),
     body: SessionCompactionRequest | None = None,
 ) -> dict[str, object]:
-    """Trigger manual context compaction for a session."""
-    
-    session = await get_session(db, session_id)
-    if session is None:
-        raise NotFound("Session not found")
+    """Trigger manual context compaction.
 
-    if stream_manager and any(job.session_id == session_id and not job.completed for job in stream_manager._jobs.values()):
-        raise Conflict("Session is currently generating")
-
-    job = GenerationJob(stream_id=f"manual-compact-{generate_ulid()}", session_id=session_id)
-    result_payload: dict[str, object] = {"ok": False}
-
-    async def _run() -> None:
-        nonlocal result_payload
-        async with session_factory() as s:
-            async with s.begin():
-                live = await get_session(s, session_id)
-                if live is not None:
-                    live.time_compacting = datetime.now(timezone.utc)
-
-        try:
-            result = await run_compaction(
-                session_id,
-                job=job,
-                session_factory=session_factory,
-                provider_registry=provider_registry,
-                agent_registry=agent_registry,
-                model_id=body.model_id if body else None,
-                visible_summary=True,
-            )
-            if not result.summary and result.pruned_parts == 0:
-                raise Conflict("Nothing to compact yet")
-            if not result.summary:
-                raise UpstreamError("Compaction pruned context but did not produce an AI summary")
-            result_payload = {
-                "ok": True,
-                "summary_created": True,
-                "pruned_parts": result.pruned_parts,
-                "visible_summary": True,
-            }
-        finally:
-            async with session_factory() as s:
-                async with s.begin():
-                    live = await get_session(s, session_id)
-                    if live is not None:
-                        live.time_compacting = None
-            job.complete()
-
-    await _run()
-    return result_payload
-
-
-@router.delete("/sessions/{session_id}")
-async def delete_session_endpoint(
-    session_id: str,
-    request: Request,
-    db: AsyncSession = Depends(get_db),
-) -> dict:
-    """Delete a session and its associated upload files."""
-    # Abort any running generation streams for this session first
-    # to prevent FK constraint errors from in-flight DB writes.
-    from app.streaming.manager import StreamManager
-
-    sm: StreamManager | None = getattr(request.app.state, "stream_manager", None)
-    if sm is not None:
-        sm.abort_session(session_id)
-
-    await delete_session_uploads(db, session_id)
-    deleted = await delete_by_id(db, Session, session_id)
-    if not deleted:
-        raise NotFound("Session not found")
-
-    # Clean up FTS resources for this session
-    index_manager = get_index_manager()
-    if index_manager is not None:
-        try:
-            await index_manager.cleanup_session(session_id)
-        except Exception:
-            pass
-
-    return {"deleted": True}
-
-
-# ---------------------------------------------------------------------------
-# Conversation export
-# ---------------------------------------------------------------------------
+    Custom (not ``route.create``) because the body is genuinely optional —
+    clients may POST with no body. ``route.create`` would force a required
+    ``SessionCompactionRequest`` body and break that contract.
+    """
+    return await compact_session_cascade(
+        db,
+        session_id,
+        body,
+        session_factory,
+        provider_registry,
+        agent_registry,
+        stream_manager,
+    )
 
 
 def _messages_to_markdown(title: str, messages: list) -> str:
-    """Convert a list of Message ORM objects into a formatted markdown string."""
+    """Format a list of Message ORM objects as a Markdown transcript."""
     now_str = datetime.now(timezone.utc).strftime("%B %d, %Y at %I:%M %p UTC")
     lines = [f"# {title}", f"*Exported on {now_str}*", "", "---", ""]
 
@@ -428,7 +310,6 @@ def _messages_to_markdown(title: str, messages: list) -> str:
         role = data.get("role", "user")
         label = "You" if role == "user" else "Assistant"
 
-        # Collect text parts only — skip reasoning, tools, steps, etc.
         text_parts: list[str] = []
         for part in msg.parts:
             pd = part.data or {}
@@ -450,12 +331,25 @@ def _messages_to_markdown(title: str, messages: list) -> str:
     return "\n".join(lines)
 
 
-@router.get("/sessions/{session_id}/export-pdf")
-async def export_session_pdf(
+def _content_disposition(title: str, ext: str) -> str:
+    """RFC-5987 ``Content-Disposition`` for an export filename."""
+    from urllib.parse import quote
+
+    safe_title = "".join(
+        c if c.isascii() and (c.isalnum() or c in " _-") else "_" for c in title
+    )
+    utf8_title = quote(title, safe="")
+    return (
+        f'attachment; filename="{safe_title}.{ext}"; '
+        f"filename*=UTF-8''{utf8_title}.{ext}"
+    )
+
+
+async def _export_session_pdf(
     session_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Export an entire conversation as a formatted PDF."""
+    """Export a session as PDF."""
     session = await get_session(db, session_id)
     if session is None:
         raise NotFound("Session not found")
@@ -466,23 +360,10 @@ async def export_session_pdf(
     try:
         md_content = _messages_to_markdown(title, messages)
         pdf_bytes = markdown_to_pdf(md_content)
-
-        # RFC 5987: filename for ASCII fallback, filename* for UTF-8 (Unicode titles)
-        from urllib.parse import quote
-        safe_title = "".join(
-            c if c.isascii() and (c.isalnum() or c in " _-") else "_" for c in title
-        )
-        utf8_title = quote(title, safe="")
-
         return Response(
             content=pdf_bytes,
             media_type="application/pdf",
-            headers={
-                "Content-Disposition": (
-                    f'attachment; filename="{safe_title}.pdf"; '
-                    f"filename*=UTF-8''{utf8_title}.pdf"
-                ),
-            },
+            headers={"Content-Disposition": _content_disposition(title, "pdf")},
         )
     except DomainError:
         raise
@@ -491,12 +372,11 @@ async def export_session_pdf(
         raise InternalError(str(exc)) from exc
 
 
-@router.get("/sessions/{session_id}/export-md")
-async def export_session_markdown(
+async def _export_session_markdown(
     session_id: str,
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Export an entire conversation as a Markdown file."""
+    """Export a session as Markdown."""
     session = await get_session(db, session_id)
     if session is None:
         raise NotFound("Session not found")
@@ -505,19 +385,21 @@ async def export_session_markdown(
     title = session.title or "Conversation"
     md_content = _messages_to_markdown(title, messages)
 
-    from urllib.parse import quote
-    safe_title = "".join(
-        c if c.isascii() and (c.isalnum() or c in " _-") else "_" for c in title
-    )
-    utf8_title = quote(title, safe="")
-
     return Response(
         content=md_content.encode("utf-8"),
         media_type="text/markdown; charset=utf-8",
-        headers={
-            "Content-Disposition": (
-                f'attachment; filename="{safe_title}.md"; '
-                f"filename*=UTF-8''{utf8_title}.md"
-            ),
-        },
+        headers={"Content-Disposition": _content_disposition(title, "md")},
     )
+
+
+route.custom("GET", "/sessions/{session_id}/todos", handler=_list_session_todos)
+route.custom("GET", "/sessions/{session_id}/files", handler=_list_session_files)
+route.custom("POST", "/sessions/{session_id}/compact", handler=_compact_session)
+route.custom("GET", "/sessions/{session_id}/export-pdf", handler=_export_session_pdf)
+route.custom("GET", "/sessions/{session_id}/export-md", handler=_export_session_markdown)
+
+
+# Exposed for app/api/router.py — preserves the existing
+# `from app.api import sessions as sessions_api; include_router(sessions_api.router)`
+# contract.
+router = route.api_router

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -63,3 +63,9 @@ class SessionList(BaseModel):
 
     items: list[SessionResponse]
     total: int
+
+
+class SessionCompactionRequest(BaseModel):
+    """Optional body for POST /sessions/{id}/compact."""
+
+    model_id: str | None = None

--- a/backend/app/session/manager.py
+++ b/backend/app/session/manager.py
@@ -2,18 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from sqlalchemy import func, select, text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import selectinload
+from sqlalchemy.orm.attributes import flag_modified
 
+from app.agent.agent import AgentRegistry
+from app.errors import Conflict, NotFound, UpstreamError
 from app.models.message import Message, Part
 from app.models.session import Session
-from app.storage.repository import create, get_all, get_by_id
+from app.provider.registry import ProviderRegistry
+from app.schemas.session import (
+    SessionCompactionRequest,
+    SessionResponse,
+    SessionSearchResult,
+    SessionUpdate,
+)
+from app.storage.repository import create, delete_by_id, get_all, get_by_id
+from app.streaming.manager import GenerationJob, StreamManager
 from app.utils.id import generate_ulid
 
 logger = logging.getLogger(__name__)
@@ -65,16 +78,24 @@ async def list_sessions(
 
 async def search_sessions(
     db: AsyncSession,
-    query: str,
+    q: str,
     *,
     limit: int = 20,
     offset: int = 0,
-) -> list[dict[str, Any]]:
+) -> list[SessionSearchResult]:
     """Search sessions by title and message text content.
 
-    Returns a list of dicts with 'session' (Session) and 'snippet' (str|None).
-    Content matches include a text excerpt; title-only matches have snippet=None.
+    Returns a list of :class:`SessionSearchResult`. Content matches include a
+    text excerpt; title-only matches have ``snippet=None``. An empty or
+    whitespace-only ``q`` returns ``[]`` without touching the DB.
+
+    The parameter is named ``q`` (not ``query``) because the route layer
+    binds Manager params to URL queries by name, and the public API has
+    always exposed this as ``?q=...``.
     """
+    if not q.strip():
+        return []
+    query = q.strip()
     # Single query that returns all session columns + snippet,
     # avoiding the N+1 problem of looping get_by_id per result.
     stmt = text("""
@@ -128,14 +149,16 @@ async def search_sessions(
     sessions_result = await db.execute(sessions_stmt)
     session_map = {s.id: s for s in sessions_result.scalars().all()}
 
-    results: list[dict[str, Any]] = []
+    results: list[SessionSearchResult] = []
     for row in rows:
         session = session_map.get(row["id"])
         if session:
-            results.append({
-                "session": session,
-                "snippet": row["snippet"],
-            })
+            results.append(
+                SessionSearchResult(
+                    session=SessionResponse.model_validate(session),
+                    snippet=row["snippet"],
+                )
+            )
     return results
 
 
@@ -683,3 +706,194 @@ def _build_user_content_with_files(
             })
 
     return content
+
+
+# ---------------------------------------------------------------------------
+# Session cascades — multi-step orchestration consumed by the Route Module
+# decorated /sessions endpoints (per ADR-0007). Each cascade takes typed
+# primitives plus long-lived services already in `_TYPE_TO_INJECTOR`; no
+# Request, no app.state. Optional services (e.g. `IndexManager`, which is
+# absent when FTS is disabled) are reached for internally rather than
+# injected, to keep the dep map non-Optional.
+# ---------------------------------------------------------------------------
+
+
+def _trigger_index(directory: str | None, session_id: str) -> None:
+    """Fire-and-forget FTS index for *directory* if FTS is configured."""
+    from app.dependencies import get_index_manager
+
+    if not directory:
+        return
+    index_manager = get_index_manager()
+    if index_manager is None:
+        return
+    asyncio.create_task(
+        index_manager.ensure_index(directory, session_id),
+        name=f"fts-trigger-{session_id[:12]}",
+    )
+
+
+async def create_session_and_index(
+    db: AsyncSession,
+    *,
+    project_id: str | None = None,
+    directory: str | None = None,
+    title: str | None = None,
+) -> Session:
+    """Create a session and trigger FTS indexing for its directory."""
+    session = await create_session(
+        db,
+        project_id=project_id,
+        directory=directory,
+        title=title,
+    )
+    _trigger_index(directory, session.id)
+    return session
+
+
+async def update_session(
+    db: AsyncSession,
+    session_id: str,
+    body: SessionUpdate,
+) -> Session:
+    """Apply partial updates to a session.
+
+    Raises :class:`NotFound` if the session doesn't exist. Triggers FTS
+    reindex on directory change. Preserves ``time_updated`` for
+    metadata-only updates (pin / archive) so the session list ordering
+    doesn't reshuffle on those toggles.
+    """
+    session = await get_session(db, session_id)
+    if session is None:
+        raise NotFound("Session not found")
+
+    original_time_updated = session.time_updated
+    metadata_only_fields = {"is_pinned", "time_archived"}
+    preserve_time_updated = (
+        bool(body.model_fields_set)
+        and body.model_fields_set <= metadata_only_fields
+    )
+
+    if body.title is not None:
+        session.title = body.title
+    if body.directory is not None:
+        session.directory = body.directory
+        _trigger_index(body.directory, session_id)
+    if "time_archived" in body.model_fields_set:
+        session.time_archived = body.time_archived
+    if body.is_pinned is not None:
+        session.is_pinned = body.is_pinned
+    if body.permission is not None:
+        session.permission = body.permission
+    if preserve_time_updated:
+        session.time_updated = original_time_updated
+        flag_modified(session, "time_updated")
+
+    await db.flush()
+    await db.refresh(session)
+    return session
+
+
+async def delete_session_cascade(
+    db: AsyncSession,
+    session_id: str,
+    stream_manager: StreamManager,
+) -> dict[str, bool]:
+    """Delete a session, abort in-flight streams, and clean up FTS.
+
+    Streams are aborted *before* the row delete so in-flight DB writes
+    don't trip foreign-key constraints. Raises :class:`NotFound` if no
+    row was deleted.
+    """
+    from app.dependencies import get_index_manager
+
+    if stream_manager is not None:
+        stream_manager.abort_session(session_id)
+
+    await delete_session_uploads(db, session_id)
+    deleted = await delete_by_id(db, Session, session_id)
+    if not deleted:
+        raise NotFound("Session not found")
+
+    index_manager = get_index_manager()
+    if index_manager is not None:
+        try:
+            await index_manager.cleanup_session(session_id)
+        except Exception:
+            logger.warning(
+                "FTS cleanup failed for session %s",
+                session_id,
+                exc_info=True,
+            )
+
+    return {"deleted": True}
+
+
+async def compact_session_cascade(
+    db: AsyncSession,
+    session_id: str,
+    body: SessionCompactionRequest | None,
+    session_factory: async_sessionmaker[AsyncSession],
+    provider_registry: ProviderRegistry,
+    agent_registry: AgentRegistry,
+    stream_manager: StreamManager,
+) -> dict[str, object]:
+    """Run manual compaction for a session.
+
+    Raises :class:`NotFound` when the session doesn't exist,
+    :class:`Conflict` when a generation is already running on this
+    session or there is nothing to compact, and :class:`UpstreamError`
+    when the provider pruned context but failed to produce a summary.
+    """
+    from app.session.compaction import run_compaction
+
+    session = await get_session(db, session_id)
+    if session is None:
+        raise NotFound("Session not found")
+
+    if stream_manager and any(
+        job.session_id == session_id and not job.completed
+        for job in stream_manager._jobs.values()
+    ):
+        raise Conflict("Session is currently generating")
+
+    job = GenerationJob(
+        stream_id=f"manual-compact-{generate_ulid()}",
+        session_id=session_id,
+    )
+
+    async with session_factory() as s:
+        async with s.begin():
+            live = await get_session(s, session_id)
+            if live is not None:
+                live.time_compacting = datetime.now(timezone.utc)
+
+    try:
+        result = await run_compaction(
+            session_id,
+            job=job,
+            session_factory=session_factory,
+            provider_registry=provider_registry,
+            agent_registry=agent_registry,
+            model_id=body.model_id if body else None,
+            visible_summary=True,
+        )
+        if not result.summary and result.pruned_parts == 0:
+            raise Conflict("Nothing to compact yet")
+        if not result.summary:
+            raise UpstreamError(
+                "Compaction pruned context but did not produce an AI summary"
+            )
+        return {
+            "ok": True,
+            "summary_created": True,
+            "pruned_parts": result.pruned_parts,
+            "visible_summary": True,
+        }
+    finally:
+        async with session_factory() as s:
+            async with s.begin():
+                live = await get_session(s, session_id)
+                if live is not None:
+                    live.time_compacting = None
+        job.complete()

--- a/backend/tests/test_api/test_route.py
+++ b/backend/tests/test_api/test_route.py
@@ -13,6 +13,8 @@ import httpx
 import pytest
 from fastapi import FastAPI, Request
 from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api._route import Route, RouteSignatureError, _validate_and_bind
 from app.errors import Conflict, NotFound, register_error_handlers
@@ -73,6 +75,37 @@ def test_validation_accepts_typed_path_only_manager():
     assert plan.queries == {}
     assert plan.body_param is None
     assert plan.body_fields == []
+
+
+class _UnrelatedBody(BaseModel):
+    other_field: str
+
+
+def test_validation_rejects_basemodel_param_when_no_body_declared():
+    async def bad(payload: _UnrelatedBody) -> str:
+        return payload.other_field
+
+    with pytest.raises(RouteSignatureError, match="route declares no"):
+        _validate_and_bind(bad, path="", body=None)
+
+
+def test_validation_rejects_basemodel_param_that_doesnt_match_body():
+    class DeclaredBody(BaseModel):
+        x: int
+
+    async def bad(payload: _UnrelatedBody) -> str:
+        return payload.other_field
+
+    with pytest.raises(RouteSignatureError, match="does not match the declared body"):
+        _validate_and_bind(bad, path="", body=DeclaredBody)
+
+
+def test_validation_rejects_underscore_body_param_name():
+    async def bad(_body: str) -> str:
+        return _body
+
+    with pytest.raises(RouteSignatureError, match="forbidden param"):
+        _validate_and_bind(bad, path="", body=None)
 
 
 # ---------------------------------------------------------------------------
@@ -348,3 +381,85 @@ def test_stream_handler_must_accept_stream_id():
 
     with pytest.raises(RouteSignatureError, match="stream_id"):
         route.stream("/x", handler=no_stream_id, method="GET")
+
+
+# ---------------------------------------------------------------------------
+# AsyncSession injection — most-exercised dep path in PR-C
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_session_injected_via_get_db(db_engine, session_factory):
+    """Manager declaring `db: AsyncSession` gets a live, working session."""
+    from app.dependencies import get_db
+
+    captured: dict[str, AsyncSession] = {}
+
+    async def list_via_db(db: AsyncSession) -> list[dict]:
+        captured["db"] = db
+        result = await db.execute(text("select 1"))
+        return [{"x": result.scalar()}]
+
+    app = FastAPI()
+    register_error_handlers(app)
+
+    async def _override_get_db():
+        async with session_factory() as session:
+            async with session.begin():
+                yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    route = Route(prefix="/db")
+    route.list("", manager=list_via_db, response_model=list[dict])
+    app.include_router(route.api_router)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/db")
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"x": 1}]
+    assert isinstance(captured["db"], AsyncSession)
+
+
+# ---------------------------------------------------------------------------
+# `request.state.user` coercion — defends the audit parser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_user_coerced_when_state_user_is_object(caplog):
+    """Non-string `request.state.user` is coerced — protects key=value parsing."""
+
+    class _UserObj:
+        def __str__(self) -> str:
+            return "user-42"
+
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.middleware("http")
+    async def set_object_user(request: Request, call_next):
+        request.state.user = _UserObj()
+        return await call_next(request)
+
+    async def echo() -> dict:
+        return {"ok": True}
+
+    route = Route(prefix="/u")
+    route.list("", manager=echo, response_model=dict)
+    app.include_router(route.api_router)
+
+    transport = httpx.ASGITransport(app=app)
+    with caplog.at_level(logging.INFO, logger="app.audit"):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/u")
+            assert resp.status_code == 200
+
+    audit_records = [r for r in caplog.records if r.message.startswith("audit ")]
+    assert len(audit_records) == 1
+    assert "user=user-42" in audit_records[0].message
+    # Critically: no whitespace inside the user value, so parser sees one field.
+    user_field = next(p for p in audit_records[0].message.split() if p.startswith("user="))
+    assert user_field == "user=user-42"

--- a/docs/adr/0007-route-module-thin-api-layer.md
+++ b/docs/adr/0007-route-module-thin-api-layer.md
@@ -42,3 +42,5 @@ Why two lines instead of one:
 **No per-chunk audit.** Considered and rejected: a 30-second generation with 200 chunks × concurrent streams blows up audit volume by 2-3 orders of magnitude with no analytical payoff — chunk-level data is already in the streaming replay buffer (ADR-0004) when needed. The audit layer's unit of accountability is the request lifecycle, not the wire frame.
 
 The decorator owns log emission; route handlers do not call `logger.info("audit ...")` themselves. If a handler needs richer business-event logging it does so under a different logger name to keep the audit channel clean.
+
+**Logger name: `app.audit`.** All four lines (`audit`, `audit.stream.open`, `audit.stream.close`) are emitted on this logger so consumers can grep / filter / route them as a single channel.


### PR DESCRIPTION
Closes #24. Final PR in the three-PR phasing — PR-A (#61, DomainError), PR-B (#64, Route Module foundation) already merged.

## What landed

**Two commits:**

1. **prep** — applies #64 review items 1-7 + the subtle-behavior callout, picked up here because PR-C touches the same `_route.py` paths anyway.
2. **migration** — sessions.py + manager.py + the ADR logger-name pin.

## sessions.py — 522 → 405 lines (−117)

11 endpoints, all go through `Route`:

| Endpoint | Decorator |
|----------|-----------|
| GET `/sessions` | `route.list` → `list_sessions` |
| GET `/sessions/search` | `route.list` → `search_sessions` |
| POST `/sessions` | `route.create` → `create_session_and_index` |
| GET `/sessions/{id}` | `route.get(not_found_on_none=True)` → `get_session` |
| PATCH `/sessions/{id}` | `route.update` → `update_session` |
| DELETE `/sessions/{id}` | `route.delete` → `delete_session_cascade` |
| GET `/sessions/{id}/todos` | `route.custom` |
| GET `/sessions/{id}/files` | `route.custom` |
| POST `/sessions/{id}/compact` | `route.custom` (body genuinely optional — see below) |
| GET `/sessions/{id}/export-pdf` | `route.custom` |
| GET `/sessions/{id}/export-md` | `route.custom` |

The five `route.custom` cases each justify the escape hatch: binary `Response` exports, file-system probing, optional-body compact. Pretending these fit the typed-Manager contract would invent more decorator surface than warranted (one-adapter rule).

## manager.py — cascades absorbed

Four new free functions in `app/session/manager.py`:

- `create_session_and_index` — wraps `create_session` with FTS trigger
- `update_session(db, session_id, body: SessionUpdate)` — partial update + time_updated preservation + reindex on directory change
- `delete_session_cascade(db, session_id, stream_manager)` — abort streams → delete uploads → delete row → FTS cleanup, in dependency order
- `compact_session_cascade(...)` — full compaction lifecycle including time_compacting marker, GenerationJob bookkeeping, error classification (`Conflict` for "nothing to compact" / "currently generating", `UpstreamError` for provider failures)

`search_sessions` refactored: param `query` → `q` matching the URL contract, returns `list[SessionSearchResult]` directly (was `list[dict]`), empty-q early return moved into the manager. No other callers — verified via grep before changing.

`SessionCompactionRequest` moved from `api/sessions.py` to `schemas/session.py` since manager-layer code now consumes it.

## Why `route.custom` for compact

The current contract is "body is optional — POST without a body, with `{}`, or with `{model_id: ...}` all work". `route.create(body=SessionCompactionRequest)` would force a required body and break that contract. Wrapping the manager call in a 14-line `route.custom` handler preserves the public API exactly.

## `_TYPE_TO_INJECTOR` extension

Added per-sub-issue, as expected:

- `StreamManager` → `get_stream_manager` (delete cascade, compact cascade)
- `ProviderRegistry` → `get_provider_registry` (compact cascade)
- `AgentRegistry` → `get_agent_registry` (compact cascade)
- `async_sessionmaker` → `get_session_factory` (compact cascade)

Generic alias lookup added via `typing.get_origin` so `async_sessionmaker[AsyncSession]` resolves to the same injector as the unparameterised class. Optional services (`IndexManager`, which is absent when FTS is disabled) are reached for internally inside the cascades — keeps the dep map non-Optional.

## #64 review items absorbed

1. ✓ `from app.errors import NotFound` to module top
2. ✓ `request.state.user` coerced to str + contract documented
3. ✓ AsyncSession injection integration test
4. ✓ body-mismatch BaseModel param fail-fast at decoration time
5. ✓ dead `status_code = 404` line removed
6. ✓ no-op ternary collapsed
7. ✓ `_body` added to `_FORBIDDEN_PARAM_NAMES`
8. ✓ ADR-0007 logger name pinned (`app.audit`)
9. — deferred (custom/stream Request heuristic) per reviewer's call

Subtle-behavior comment added in `_build_endpoint`'s `finally` block: audit reflects Manager outcome, so a downstream `response_model` failure logs status=success while client receives 500. Dashboards consuming audit treat error-handler logs as authoritative on 500s.

## Verification

- **Public HTTP contract preserved**: 16/16 existing `tests/test_api/test_sessions.py` tests pass without modification — same status codes, same body shapes, same query param names.
- **Full suite**: 763 passed / 20 skipped (same as PR-B baseline).
- **Invariants**:
  - No `HTTPException` raises in `sessions.py` (verified via `grep -n "HTTPException" app/api/sessions.py` → no output)
  - No `app.state` reads inside Manager calls
  - All 11 endpoints use Route decorators
  - Two cascades collapsed into manager free functions

## Out of scope (per #24's revised scope)

- `multipart` decorator — defer until #32 (files.py uploads) needs it
- `TestRouteRegistry` — split out as #60
- Tightening the `InternalError(str(exc))` echo in `_export_session_pdf` — that's a pre-existing leak smell, separate concern from this migration
- Refactoring the four `route.custom` handlers — they're correctly using the escape hatch; no point pretending they're CRUD

Refs #24, ADR-0007, ADR-0008.