### PR TITLE
feat(channels): ChatChannel + VendorTransport foundation (#20 PR-D1)

### DIFF
--- a/backend/app/channels/chat/__init__.py
+++ b/backend/app/channels/chat/__init__.py
@@ -1,0 +1,36 @@
+"""Chat-style Channel scaffolding (ADR-0006).
+
+`ChatChannel` is the fast path for chat-style Channels — Feishu, WeChat,
+Telegram, Slack, Discord, DingTalk — that share ~80% of their wiring:
+inbound dispatch with allowlist + mention/reply policy, streaming-card
+buffer with edit throttling, media-group buffer, text chunking, retry
+with backoff, typing indicator loop. The vendor-specific bits — auth,
+send/edit/upload API calls, markdown rendering, mention parsing — are
+provided through an injected :class:`VendorTransport` Protocol.
+
+Channels that don't fit the chat shape (Email, RSS, voice) continue to
+subclass :class:`app.channels.base.BaseChannel` directly.
+"""
+
+from __future__ import annotations
+
+from app.channels.chat.channel import ChatChannel
+from app.channels.chat.profile import ChatProfile
+from app.channels.chat.recording import RecordingTransport, RecordedCall
+from app.channels.chat.transport import (
+    ChatInbound,
+    MediaKind,
+    VendorMessageRef,
+    VendorTransport,
+)
+
+__all__ = [
+    "ChatChannel",
+    "ChatInbound",
+    "ChatProfile",
+    "MediaKind",
+    "RecordedCall",
+    "RecordingTransport",
+    "VendorMessageRef",
+    "VendorTransport",
+]

--- a/backend/app/channels/chat/channel.py
+++ b/backend/app/channels/chat/channel.py
@@ -1,0 +1,504 @@
+"""``ChatChannel`` — shared scaffolding for chat-style Channels (ADR-0006).
+
+Composes a :class:`VendorTransport` with a :class:`ChatProfile` to deliver
+the eight pieces of behaviour every chat Channel needs:
+
+1. **Allowlist + group-policy gating** — filters out unauthorised senders
+   and (in groups) messages that don't mention the bot or reply to it,
+   reusing :meth:`BaseChannel.is_allowed` for the first half.
+2. **Reaction tracking** — adds an inbound emoji reaction when a turn
+   starts, removes it when the final response sends. Uses the opaque
+   token returned by :meth:`VendorTransport.add_reaction` so vendors
+   that need a reaction id (Feishu) and vendors that don't (Telegram)
+   share the same code path.
+3. **Typing indicator loop** — best-effort visible feedback while a turn
+   is in flight; cancelled on send completion.
+4. **Media-group buffer** — vendors that emit one inbound event per
+   media item in an album (Telegram, Feishu) get coalesced into a
+   single ``InboundMessage``.
+5. **Streaming buffer with edit-throttle** — the streaming-card pattern:
+   first delta sends a new message and stores the ref, subsequent deltas
+   edit it in place, throttled by ``profile.stream_edit_interval``.
+6. **Text chunking** — outbound text longer than ``profile.max_message_len``
+   is split via :func:`app.channels.helpers.split_message`.
+7. **Send retry with backoff** — wraps every transport send/edit call with
+   ``profile.send_retries`` exponential-backoff attempts.
+8. **Lifecycle** — ``start()`` hands the transport an inbound callback;
+   ``stop()`` cancels typing tasks, flushes pending media-group buffers,
+   and tears down the transport.
+
+Vendor-specific behaviour — auth, polling, parsing, markdown rendering,
+API call shapes — lives behind :class:`VendorTransport`. The
+:class:`RecordingTransport` test adapter exercises every code path here
+without any real vendor SDK in the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.channels.base import BaseChannel
+from app.channels.bus.events import OutboundMessage
+from app.channels.bus.queue import MessageBus
+from app.channels.chat.profile import ChatProfile
+from app.channels.chat.transport import (
+    ChatInbound,
+    VendorMessageRef,
+    VendorTransport,
+)
+from app.channels.helpers import split_message
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _StreamBuf:
+    """Per-chat accumulator that backs streaming-card editing."""
+
+    text: str = ""
+    ref: VendorMessageRef | None = None
+    last_edit_perf: float = 0.0
+    stream_id: str | None = None
+
+
+@dataclass
+class _MediaGroupBuf:
+    """Per-(chat,group_id) accumulator backing media-group coalescing."""
+
+    sender_id: str
+    chat_id: str
+    contents: list[str] = field(default_factory=list)
+    media: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    session_key: str | None = None
+    first_message_ref: VendorMessageRef | None = None
+
+
+class ChatChannel(BaseChannel):
+    """Concrete :class:`BaseChannel` for chat-style vendors.
+
+    Subclass this only to override the ``name`` / ``display_name`` class
+    attributes for routing — most behaviour comes from the injected
+    :class:`VendorTransport` plus the :class:`ChatProfile`. The Telegram
+    Channel, for example, is a 30-line composer that wires
+    ``TelegramTransport`` to the right ``ChatProfile`` and inherits the
+    rest from here.
+    """
+
+    def __init__(
+        self,
+        config: Any,
+        bus: MessageBus,
+        *,
+        transport: VendorTransport,
+        profile: ChatProfile,
+    ) -> None:
+        super().__init__(config, bus)
+        self.transport = transport
+        self.profile = profile
+        self._typing_tasks: dict[str, asyncio.Task] = {}
+        self._stream_bufs: dict[str, _StreamBuf] = {}
+        self._media_group_buffers: dict[str, _MediaGroupBuf] = {}
+        self._media_group_tasks: dict[str, asyncio.Task] = {}
+        # (chat_id, message_id) -> opaque reaction token from transport.
+        # Looked up at send-time to remove the inbound reaction once the
+        # final response goes out.
+        self._reaction_tokens: dict[tuple[str, str], Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        self._running = True
+        await self.transport.start(on_inbound=self._handle_inbound_envelope)
+
+    async def stop(self) -> None:
+        self._running = False
+        for chat_id in list(self._typing_tasks):
+            self._stop_typing(chat_id)
+        for task in self._media_group_tasks.values():
+            task.cancel()
+        self._media_group_tasks.clear()
+        self._media_group_buffers.clear()
+        self._stream_bufs.clear()
+        self._reaction_tokens.clear()
+        await self.transport.stop()
+
+    @property
+    def supports_streaming(self) -> bool:
+        cfg = self.config
+        streaming = cfg.get("streaming", False) if isinstance(cfg, dict) else getattr(cfg, "streaming", False)
+        return bool(streaming) and self.profile.supports_edit
+
+    # ------------------------------------------------------------------
+    # Inbound — allowlist + group-policy + media-group buffer + dispatch
+    # ------------------------------------------------------------------
+
+    async def _handle_inbound_envelope(self, env: ChatInbound) -> None:
+        """Callback for the transport. Applies policy, then dispatches."""
+        if not self.is_allowed(env.sender_id):
+            logger.info(
+                "%s: dropped inbound from sender %s (not in allow_from)",
+                self.name, env.sender_id,
+            )
+            return
+
+        if env.is_group and not self._group_message_for_bot(env):
+            return
+
+        if env.media_group_id and self.profile.media_group_buffer_ms > 0:
+            await self._buffer_media_group(env)
+            return
+
+        await self._dispatch_inbound(env)
+
+    def _group_message_for_bot(self, env: ChatInbound) -> bool:
+        """Apply ``group_policy``: open lets everything through, mention
+        requires either an @mention or a reply to a bot message."""
+        policy = getattr(self.config, "group_policy", "mention")
+        if isinstance(self.config, dict):
+            policy = self.config.get("group_policy", "mention")
+        if policy == "open":
+            return True
+        return env.is_mention_to_bot or env.is_reply_to_bot
+
+    async def _buffer_media_group(self, env: ChatInbound) -> None:
+        """Coalesce album-style inbound events into one bus dispatch."""
+        key = f"{env.chat_id}:{env.media_group_id}"
+        buf = self._media_group_buffers.get(key)
+        if buf is None:
+            buf = _MediaGroupBuf(
+                sender_id=env.sender_id,
+                chat_id=env.chat_id,
+                metadata=dict(env.metadata),
+                session_key=env.session_key,
+                first_message_ref=env.message_ref,
+            )
+            self._media_group_buffers[key] = buf
+            self._start_typing(env.chat_id)
+            await self._react_to_inbound(env)
+
+        if env.content:
+            buf.contents.append(env.content)
+        buf.media.extend(env.media)
+
+        if key not in self._media_group_tasks:
+            self._media_group_tasks[key] = asyncio.create_task(
+                self._flush_media_group(key),
+                name=f"media-group-{key[:24]}",
+            )
+
+    async def _flush_media_group(self, key: str) -> None:
+        try:
+            await asyncio.sleep(self.profile.media_group_buffer_ms / 1000)
+            buf = self._media_group_buffers.pop(key, None)
+            if buf is None:
+                return
+            content = "\n".join(buf.contents) if buf.contents else "[empty message]"
+            await self._handle_message(
+                sender_id=buf.sender_id,
+                chat_id=buf.chat_id,
+                content=content,
+                media=list(dict.fromkeys(buf.media)),
+                metadata=buf.metadata,
+                session_key=buf.session_key,
+            )
+        finally:
+            self._media_group_tasks.pop(key, None)
+
+    async def _dispatch_inbound(self, env: ChatInbound) -> None:
+        """Non-media-group path: react, type, then publish."""
+        await self._react_to_inbound(env)
+        self._start_typing(env.chat_id)
+        await self._handle_message(
+            sender_id=env.sender_id,
+            chat_id=env.chat_id,
+            content=env.content,
+            media=list(env.media),
+            metadata=env.metadata,
+            session_key=env.session_key,
+        )
+
+    async def _react_to_inbound(self, env: ChatInbound) -> None:
+        """Best-effort emoji reaction on the inbound message."""
+        emoji = self._react_emoji()
+        if not emoji:
+            return
+        try:
+            token = await self.transport.add_reaction(env.message_ref, emoji)
+        except Exception as exc:
+            logger.debug("%s: add_reaction failed: %s", self.name, exc)
+            return
+        self._reaction_tokens[
+            (env.message_ref.chat_id, env.message_ref.message_id)
+        ] = token
+
+    def _react_emoji(self) -> str | None:
+        cfg = self.config
+        if isinstance(cfg, dict):
+            return cfg.get("react_emoji")
+        return getattr(cfg, "react_emoji", None)
+
+    # ------------------------------------------------------------------
+    # Outbound — send + retry + chunking + reaction cleanup
+    # ------------------------------------------------------------------
+
+    async def send(self, msg: OutboundMessage) -> None:
+        is_progress = bool(msg.metadata.get("_progress"))
+        if not is_progress:
+            self._stop_typing(msg.chat_id)
+            await self._remove_inbound_reaction(msg)
+
+        reply_ref = self._inbound_ref_from_outbound(msg)
+        thread_id = self._thread_id_from_outbound(msg)
+
+        for media_path in msg.media or []:
+            kind = self._infer_media_kind(media_path)
+            try:
+                await self._with_retry(
+                    self.transport.send_media,
+                    msg.chat_id,
+                    media_path,
+                    kind,
+                    reply_to=reply_ref,
+                    thread_id=thread_id,
+                )
+            except Exception as exc:
+                logger.error("%s: media send failed for %s: %s", self.name, media_path, exc)
+
+        if msg.content and msg.content != "[empty message]":
+            render = (
+                self.transport.render_quote
+                if msg.metadata.get("_tool_hint")
+                else self.transport.render_text
+            )
+            for chunk in split_message(msg.content, self.profile.max_message_len):
+                await self._with_retry(
+                    self.transport.send_text,
+                    msg.chat_id,
+                    render(chunk),
+                    reply_to=reply_ref,
+                    thread_id=thread_id,
+                )
+
+    async def send_delta(
+        self,
+        chat_id: str,
+        delta: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if not self.profile.supports_edit:
+            # Vendors without edit fall back to chunked send-on-end.
+            return
+        meta = metadata or {}
+        stream_id = meta.get("_stream_id")
+
+        if meta.get("_stream_end"):
+            await self._finalize_stream(chat_id, stream_id, meta)
+            return
+
+        buf = self._stream_bufs.get(chat_id)
+        if buf is None or (
+            stream_id is not None and buf.stream_id is not None and buf.stream_id != stream_id
+        ):
+            buf = _StreamBuf(stream_id=stream_id)
+            self._stream_bufs[chat_id] = buf
+        elif buf.stream_id is None:
+            buf.stream_id = stream_id
+
+        buf.text += delta
+        if not buf.text.strip():
+            return
+
+        thread_id = meta.get("message_thread_id")
+        now_perf = time.perf_counter()
+
+        if buf.ref is None:
+            try:
+                buf.ref = await self._with_retry(
+                    self.transport.send_text,
+                    chat_id,
+                    self.transport.render_text(buf.text),
+                    thread_id=thread_id,
+                )
+                buf.last_edit_perf = now_perf
+            except Exception as exc:
+                logger.warning("%s: stream initial send failed: %s", self.name, exc)
+                raise
+        elif (now_perf - buf.last_edit_perf) >= self.profile.stream_edit_interval:
+            try:
+                await self._with_retry(
+                    self.transport.edit_text,
+                    buf.ref,
+                    self.transport.render_text(buf.text),
+                )
+                buf.last_edit_perf = now_perf
+            except Exception as exc:
+                logger.warning("%s: stream edit failed: %s", self.name, exc)
+                raise
+
+    async def _finalize_stream(
+        self,
+        chat_id: str,
+        stream_id: Any,
+        meta: dict[str, Any],
+    ) -> None:
+        buf = self._stream_bufs.get(chat_id)
+        if not buf or not buf.ref or not buf.text:
+            return
+        if stream_id is not None and buf.stream_id is not None and buf.stream_id != stream_id:
+            return
+
+        self._stop_typing(chat_id)
+        await self._remove_inbound_reaction_by_meta(meta, chat_id)
+
+        chunks = split_message(buf.text, self.profile.max_message_len)
+        primary = chunks[0] if chunks else buf.text
+        try:
+            await self._with_retry(
+                self.transport.edit_text,
+                buf.ref,
+                self.transport.render_text(primary),
+            )
+        except Exception as exc:
+            logger.warning("%s: final stream edit failed: %s", self.name, exc)
+
+        thread_id = meta.get("message_thread_id")
+        for extra in chunks[1:]:
+            await self._with_retry(
+                self.transport.send_text,
+                chat_id,
+                self.transport.render_text(extra),
+                thread_id=thread_id,
+            )
+        self._stream_bufs.pop(chat_id, None)
+
+    # ------------------------------------------------------------------
+    # Typing indicator
+    # ------------------------------------------------------------------
+
+    def _start_typing(self, chat_id: str) -> None:
+        if self.profile.typing_indicator_interval <= 0:
+            return
+        self._stop_typing(chat_id)
+        self._typing_tasks[chat_id] = asyncio.create_task(
+            self._typing_loop(chat_id),
+            name=f"typing-{self.name}-{chat_id[:24]}",
+        )
+
+    def _stop_typing(self, chat_id: str) -> None:
+        task = self._typing_tasks.pop(chat_id, None)
+        if task and not task.done():
+            task.cancel()
+
+    async def _typing_loop(self, chat_id: str) -> None:
+        try:
+            while self._running:
+                try:
+                    await self.transport.show_typing(chat_id)
+                except Exception as exc:
+                    logger.debug("%s: typing indicator failed: %s", self.name, exc)
+                    return
+                await asyncio.sleep(self.profile.typing_indicator_interval)
+        except asyncio.CancelledError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Reaction cleanup helpers
+    # ------------------------------------------------------------------
+
+    async def _remove_inbound_reaction(self, msg: OutboundMessage) -> None:
+        message_id = msg.metadata.get("message_id")
+        if message_id is None:
+            return
+        await self._remove_reaction_by_keys(msg.chat_id, str(message_id))
+
+    async def _remove_inbound_reaction_by_meta(
+        self,
+        meta: dict[str, Any],
+        chat_id: str,
+    ) -> None:
+        message_id = meta.get("message_id")
+        if message_id is None:
+            return
+        await self._remove_reaction_by_keys(chat_id, str(message_id))
+
+    async def _remove_reaction_by_keys(self, chat_id: str, message_id: str) -> None:
+        key = (chat_id, message_id)
+        if key not in self._reaction_tokens:
+            # Either no reaction was added (no emoji configured or
+            # add_reaction failed) or this isn't an inbound we tracked.
+            # Either way, no removal call to make. Note: a stored token
+            # value of ``None`` is still a valid track — vendors whose
+            # remove_reaction works off the message ref alone return
+            # None from add_reaction.
+            return
+        token = self._reaction_tokens.pop(key)
+        ref = VendorMessageRef(chat_id=chat_id, message_id=message_id)
+        try:
+            await self.transport.remove_reaction(ref, token)
+        except Exception as exc:
+            logger.debug("%s: remove_reaction failed: %s", self.name, exc)
+
+    # ------------------------------------------------------------------
+    # Outbound helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _inbound_ref_from_outbound(msg: OutboundMessage) -> VendorMessageRef | None:
+        message_id = msg.metadata.get("message_id")
+        if message_id is None:
+            return None
+        return VendorMessageRef(chat_id=msg.chat_id, message_id=str(message_id))
+
+    @staticmethod
+    def _thread_id_from_outbound(msg: OutboundMessage) -> str | None:
+        thread = msg.metadata.get("message_thread_id")
+        return str(thread) if thread is not None else None
+
+    @staticmethod
+    def _infer_media_kind(media_path: str) -> str:
+        ext = media_path.rsplit(".", 1)[-1].lower() if "." in media_path else ""
+        if ext in ("jpg", "jpeg", "png", "gif", "webp"):
+            return "photo"
+        if ext == "ogg":
+            return "voice"
+        if ext in ("mp3", "m4a", "wav", "aac"):
+            return "audio"
+        if ext in ("mp4", "mov", "webm"):
+            return "video"
+        return "document"
+
+    async def _with_retry(self, fn, *args, **kwargs):
+        """Exponential backoff wrapper for any transport call.
+
+        Catches every ``Exception`` so the retry policy is uniform across
+        vendor SDKs (each raises its own exception types for timeouts /
+        rate limits / network errors). Vendors that need to surface a
+        non-retryable error should reraise from inside the transport.
+        """
+        attempts = max(1, self.profile.send_retries)
+        delay = self.profile.send_retry_base_delay
+        last_exc: Exception | None = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                if attempt == attempts:
+                    raise
+                logger.warning(
+                    "%s: transport call %s failed (attempt %d/%d), retrying in %.1fs: %s",
+                    self.name, getattr(fn, "__name__", "?"),
+                    attempt, attempts, delay, exc,
+                )
+                await asyncio.sleep(delay)
+                delay *= 2
+        # Should be unreachable — final attempt either returns or re-raises.
+        assert last_exc is not None
+        raise last_exc

--- a/backend/app/channels/chat/profile.py
+++ b/backend/app/channels/chat/profile.py
@@ -1,0 +1,47 @@
+"""Declarative knobs for chat-style Channels (ADR-0006)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ChatProfile:
+    """Per-vendor knobs consumed by :class:`ChatChannel`.
+
+    The profile is data, not behaviour — every value here describes a vendor
+    constraint or an operational tuning, never how to call an API. API calls
+    live behind :class:`VendorTransport`.
+
+    Attributes:
+        max_message_len: Largest text payload the vendor will accept in one
+            message. Longer outbound text is split by the chunker (Telegram
+            4000, Slack ~40000, Feishu 30000).
+        stream_edit_interval: Minimum seconds between consecutive
+            ``edit_text`` calls during streaming. Vendors flood-control
+            edits — Telegram caps around 1/s per chat in practice. 0.6 is
+            a safe default.
+        media_group_buffer_ms: Window during which inbound media-group
+            messages are batched into a single bus dispatch. ``0`` disables
+            batching (transports without media groups, e.g. Slack).
+        typing_indicator_interval: Seconds between repeats of the typing
+            indicator while a turn is in flight. ``0`` disables typing
+            (vendors without the concept).
+        send_retries: How many times to retry a vendor send on transient
+            failures (timeout, rate limit). The retry loop uses exponential
+            backoff starting at ``send_retry_base_delay``.
+        send_retry_base_delay: Initial backoff delay in seconds; doubles
+            each retry.
+        supports_edit: Whether the vendor supports editing a previously-
+            sent message. False forces ``ChatChannel`` to send each delta
+            as a new message instead of editing in place; rarely toggled —
+            most chat vendors support it.
+    """
+
+    max_message_len: int
+    stream_edit_interval: float = 0.6
+    media_group_buffer_ms: int = 600
+    typing_indicator_interval: float = 4.0
+    send_retries: int = 3
+    send_retry_base_delay: float = 0.5
+    supports_edit: bool = True

--- a/backend/app/channels/chat/recording.py
+++ b/backend/app/channels/chat/recording.py
@@ -1,0 +1,173 @@
+"""``RecordingTransport`` — in-memory test adapter for :class:`ChatChannel`.
+
+Records every call into ``calls`` so tests can assert exactly which
+transport methods fired, in what order, with what arguments. Lets tests
+inject inbound events through :meth:`push_inbound` to drive the
+Channel's policy logic. Supports failure injection through
+:meth:`fail_next` for testing the retry path.
+
+Designed for unit tests only — never wired into a real Channel manager.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.channels.chat.transport import (
+    ChatInbound,
+    InboundHandler,
+    MediaKind,
+    VendorMessageRef,
+)
+
+
+@dataclass
+class RecordedCall:
+    """One captured invocation of a :class:`RecordingTransport` method."""
+
+    method: str
+    args: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+class RecordingTransport:
+    """In-memory :class:`VendorTransport`. Pure record + replay."""
+
+    name: str = "recording"
+
+    def __init__(
+        self,
+        *,
+        render_text_prefix: str = "",
+        render_quote_prefix: str = "[QUOTE] ",
+    ) -> None:
+        self.calls: list[RecordedCall] = []
+        self._on_inbound: InboundHandler | None = None
+        self._next_message_id = 1
+        self._reaction_id = 1
+        self._render_text_prefix = render_text_prefix
+        self._render_quote_prefix = render_quote_prefix
+        # Failure injection: pop the head before each method call; if
+        # the head matches the method name, raise the configured error.
+        self._fail_queue: list[tuple[str, Exception]] = []
+        # Per-(chat, message_id) reaction tokens issued by add_reaction.
+        # Tests can introspect to verify lifecycle.
+        self.outstanding_reactions: dict[tuple[str, str], Any] = {}
+        self.started = False
+        self.stopped = False
+
+    # ---- Test-side API --------------------------------------------
+
+    async def push_inbound(self, env: ChatInbound) -> None:
+        """Drive the Channel's inbound pipeline as if the vendor had
+        produced this event."""
+        if self._on_inbound is None:
+            raise RuntimeError("Transport not started; no inbound handler registered.")
+        await self._on_inbound(env)
+
+    def fail_next(self, method: str, exc: Exception) -> None:
+        """Make the next call to ``method`` raise ``exc``. Queueable —
+        call repeatedly to inject multiple failures."""
+        self._fail_queue.append((method, exc))
+
+    def _maybe_fail(self, method: str) -> None:
+        if not self._fail_queue:
+            return
+        head_method, head_exc = self._fail_queue[0]
+        if head_method == method:
+            self._fail_queue.pop(0)
+            raise head_exc
+
+    def _record(self, method: str, *args: Any, **kwargs: Any) -> None:
+        self.calls.append(RecordedCall(method=method, args=args, kwargs=kwargs))
+
+    def methods_called(self) -> list[str]:
+        return [c.method for c in self.calls]
+
+    # ---- VendorTransport implementation ---------------------------
+
+    async def start(self, on_inbound: InboundHandler) -> None:
+        self._record("start")
+        self._on_inbound = on_inbound
+        self.started = True
+
+    async def stop(self) -> None:
+        self._record("stop")
+        self._on_inbound = None
+        self.stopped = True
+
+    async def send_text(
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        reply_to: VendorMessageRef | None = None,
+        thread_id: str | None = None,
+    ) -> VendorMessageRef:
+        self._record("send_text", chat_id=chat_id, text=text, reply_to=reply_to, thread_id=thread_id)
+        self._maybe_fail("send_text")
+        ref = VendorMessageRef(
+            chat_id=chat_id,
+            message_id=str(self._next_message_id),
+        )
+        self._next_message_id += 1
+        return ref
+
+    async def edit_text(
+        self,
+        ref: VendorMessageRef,
+        text: str,
+    ) -> None:
+        self._record("edit_text", ref=ref, text=text)
+        self._maybe_fail("edit_text")
+
+    async def send_media(
+        self,
+        chat_id: str,
+        media_path: str,
+        kind: MediaKind,
+        *,
+        reply_to: VendorMessageRef | None = None,
+        thread_id: str | None = None,
+    ) -> VendorMessageRef | None:
+        self._record(
+            "send_media",
+            chat_id=chat_id, media_path=media_path, kind=kind,
+            reply_to=reply_to, thread_id=thread_id,
+        )
+        self._maybe_fail("send_media")
+        ref = VendorMessageRef(chat_id=chat_id, message_id=str(self._next_message_id))
+        self._next_message_id += 1
+        return ref
+
+    async def show_typing(self, chat_id: str) -> None:
+        self._record("show_typing", chat_id=chat_id)
+        self._maybe_fail("show_typing")
+
+    async def add_reaction(
+        self,
+        ref: VendorMessageRef,
+        emoji: str,
+    ) -> Any:
+        self._record("add_reaction", ref=ref, emoji=emoji)
+        self._maybe_fail("add_reaction")
+        token = f"reaction-{self._reaction_id}"
+        self._reaction_id += 1
+        self.outstanding_reactions[(ref.chat_id, ref.message_id)] = token
+        return token
+
+    async def remove_reaction(
+        self,
+        ref: VendorMessageRef,
+        token: Any,
+    ) -> None:
+        self._record("remove_reaction", ref=ref, token=token)
+        self._maybe_fail("remove_reaction")
+        self.outstanding_reactions.pop((ref.chat_id, ref.message_id), None)
+
+    def render_text(self, markdown: str) -> str:
+        return self._render_text_prefix + markdown
+
+    def render_quote(self, text: str) -> str:
+        return self._render_quote_prefix + text

--- a/backend/app/channels/chat/transport.py
+++ b/backend/app/channels/chat/transport.py
@@ -1,0 +1,175 @@
+"""Vendor I/O Protocol consumed by :class:`ChatChannel` (ADR-0006).
+
+A transport implements the vendor-specific half of a chat Channel:
+authentication, listening for inbound events, sending and editing
+messages, uploading media, vendor-specific markdown rendering, and the
+opaque tokens needed to track reactions. The other half — allowlist,
+group-policy gating, streaming buffer, media-group batching, typing
+loop, chunking, retry — lives in :class:`ChatChannel` and is shared
+across vendors.
+
+The Protocol is structural (``typing.Protocol``), not nominal: vendors
+do not need to subclass it. That keeps the surface narrow — adding a
+new transport is "implement these methods on a class", not "carry the
+weight of an inheritance chain".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Literal, Protocol, runtime_checkable
+
+
+MediaKind = Literal["photo", "voice", "audio", "video", "animation", "document"]
+
+
+@dataclass(frozen=True)
+class VendorMessageRef:
+    """Opaque reference to a message that lives on the vendor side.
+
+    Returned from :meth:`VendorTransport.send_text` and
+    :meth:`VendorTransport.send_media` so ``ChatChannel`` can later
+    target the same message for edits, reactions, or threaded replies
+    without learning the vendor's id shape. ``message_id`` is always a
+    string (vendors use ints, strings, or composite tokens — we string-
+    ify for uniformity); ``extra`` carries any vendor-specific bits the
+    transport needs to thread back through (e.g. Telegram's
+    ``message_thread_id``, Slack's channel-versus-DM split).
+    """
+
+    chat_id: str
+    message_id: str
+    extra: Any = None
+
+
+@dataclass
+class ChatInbound:
+    """Vendor-agnostic inbound event produced by the transport.
+
+    The transport listens to its vendor's wire format (long-poll updates
+    for Telegram, webhook events for Slack, websocket frames for Feishu),
+    translates one event into this shape, and hands it to ``ChatChannel``
+    via the ``on_inbound`` callback. ``ChatChannel`` then runs allowlist,
+    group-policy, and media-group-batching policy on it before
+    publishing to the bus.
+    """
+
+    sender_id: str
+    chat_id: str
+    content: str
+    message_ref: VendorMessageRef
+    media: list[str] = field(default_factory=list)
+    is_group: bool = False
+    is_mention_to_bot: bool = False
+    is_reply_to_bot: bool = False
+    media_group_id: str | None = None
+    thread_id: str | None = None
+    session_key: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# Type alias for clarity — each transport is given this callback at
+# ``start()`` and must invoke it for every inbound event.
+InboundHandler = Callable[[ChatInbound], Awaitable[None]]
+
+
+@runtime_checkable
+class VendorTransport(Protocol):
+    """Vendor-specific I/O primitives. Implement structurally.
+
+    Every method is awaited; transports that wrap a synchronous SDK
+    should run blocking calls in a thread executor so the Channel's
+    event loop is never blocked.
+    """
+
+    name: str
+
+    # ---- Lifecycle --------------------------------------------------
+
+    async def start(self, on_inbound: InboundHandler) -> None:
+        """Begin listening for vendor events. Returns once the listener
+        is up; the listener itself runs until :meth:`stop` is called."""
+        ...
+
+    async def stop(self) -> None:
+        """Stop the listener and release vendor resources."""
+        ...
+
+    # ---- Outbound ---------------------------------------------------
+
+    async def send_text(
+        self,
+        chat_id: str,
+        text: str,
+        *,
+        reply_to: VendorMessageRef | None = None,
+        thread_id: str | None = None,
+    ) -> VendorMessageRef:
+        """Send a text message. The transport is responsible for any
+        vendor-specific rendering (markdown→HTML, mrkdwn, etc.) — see
+        :meth:`render_text`."""
+        ...
+
+    async def edit_text(
+        self,
+        ref: VendorMessageRef,
+        text: str,
+    ) -> None:
+        """Replace the body of a previously-sent message. Called only
+        when ``ChatProfile.supports_edit`` is True."""
+        ...
+
+    async def send_media(
+        self,
+        chat_id: str,
+        media_path: str,
+        kind: MediaKind,
+        *,
+        reply_to: VendorMessageRef | None = None,
+        thread_id: str | None = None,
+    ) -> VendorMessageRef | None:
+        """Upload and send a single media file. Returns the vendor ref
+        if the platform exposes one, ``None`` if the upload is fire-and-
+        forget (some vendors don't return ids for media)."""
+        ...
+
+    # ---- UX feedback -----------------------------------------------
+
+    async def show_typing(self, chat_id: str) -> None:
+        """Best-effort typing indicator. Transports without the concept
+        no-op."""
+        ...
+
+    async def add_reaction(
+        self,
+        ref: VendorMessageRef,
+        emoji: str,
+    ) -> Any:
+        """Add an emoji reaction. Returns an opaque token that
+        :meth:`remove_reaction` will need (Feishu's ``reaction_id``,
+        Slack's emoji name, ``None`` for vendors that key removal off
+        the message ref alone)."""
+        ...
+
+    async def remove_reaction(
+        self,
+        ref: VendorMessageRef,
+        token: Any,
+    ) -> None:
+        """Remove a previously-added reaction using the token returned
+        from :meth:`add_reaction`."""
+        ...
+
+    # ---- Rendering --------------------------------------------------
+
+    def render_text(self, markdown: str) -> str:
+        """Translate generic markdown into the vendor's rendered form
+        (Telegram HTML, Slack mrkdwn, Feishu rich-text). Pass-through
+        is a fine default for vendors with no special form."""
+        ...
+
+    def render_quote(self, text: str) -> str:
+        """Render text as a quoted block (used by ChatChannel for
+        tool-hint sections). Vendors without quoting render the same
+        as :meth:`render_text`."""
+        ...

--- a/backend/tests/test_channels/test_chat_channel.py
+++ b/backend/tests/test_channels/test_chat_channel.py
@@ -1,0 +1,449 @@
+"""Scaffolding tests for ChatChannel via RecordingTransport.
+
+Each test exercises one piece of the eight-piece scaffolding identified
+in ADR-0006 (allowlist + group policy, reactions, typing, media-group
+buffer, streaming buffer, text chunking, retry, lifecycle). The
+RecordingTransport stands in for any real vendor SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.channels.bus.events import OutboundMessage
+from app.channels.bus.queue import MessageBus
+from app.channels.chat import (
+    ChatChannel,
+    ChatInbound,
+    ChatProfile,
+    RecordingTransport,
+    VendorMessageRef,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    *,
+    allow_from=("alice",),
+    group_policy="mention",
+    streaming=True,
+    react_emoji="👀",
+):
+    return SimpleNamespace(
+        allow_from=list(allow_from),
+        group_policy=group_policy,
+        streaming=streaming,
+        react_emoji=react_emoji,
+    )
+
+
+def _make_profile(**overrides):
+    base = dict(
+        max_message_len=20,
+        stream_edit_interval=0.0,  # tests don't want to wait
+        media_group_buffer_ms=50,
+        typing_indicator_interval=0.0,  # disable by default; tests opt in
+        send_retries=2,
+        send_retry_base_delay=0.0,
+    )
+    base.update(overrides)
+    return ChatProfile(**base)
+
+
+def _make_channel(*, config=None, profile=None, transport=None):
+    bus = MessageBus()
+    transport = transport or RecordingTransport()
+    profile = profile or _make_profile()
+    config = config or _make_config()
+    return ChatChannel(
+        config=config,
+        bus=bus,
+        transport=transport,
+        profile=profile,
+    ), bus, transport
+
+
+def _inbound(
+    *,
+    sender="alice",
+    chat="chat-1",
+    content="hi",
+    media=(),
+    is_group=False,
+    mention=False,
+    reply_bot=False,
+    media_group_id=None,
+    message_id="100",
+    metadata=None,
+    session_key=None,
+):
+    return ChatInbound(
+        sender_id=sender,
+        chat_id=chat,
+        content=content,
+        message_ref=VendorMessageRef(chat_id=chat, message_id=message_id),
+        media=list(media),
+        is_group=is_group,
+        is_mention_to_bot=mention,
+        is_reply_to_bot=reply_bot,
+        media_group_id=media_group_id,
+        metadata=dict(metadata or {"message_id": message_id}),
+        session_key=session_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_start_stop_delegates_to_transport():
+    channel, _, transport = _make_channel()
+    await channel.start()
+    assert transport.started is True
+    assert transport.methods_called() == ["start"]
+    await channel.stop()
+    assert transport.stopped is True
+    assert "stop" in transport.methods_called()
+
+
+async def test_stop_cancels_typing_tasks():
+    profile = _make_profile(typing_indicator_interval=10)
+    channel, _, transport = _make_channel(profile=profile)
+    await channel.start()
+    channel._start_typing("c-1")
+    assert "c-1" in channel._typing_tasks
+    await channel.stop()
+    assert channel._typing_tasks == {}
+
+
+# ---------------------------------------------------------------------------
+# Allowlist + group policy
+# ---------------------------------------------------------------------------
+
+
+async def test_allowlist_blocks_unknown_sender():
+    channel, bus, transport = _make_channel()
+    await channel.start()
+    await transport.push_inbound(_inbound(sender="mallory"))
+    assert bus.inbound_size == 0
+    # No reaction either — the message was dropped before side effects.
+    assert "add_reaction" not in transport.methods_called()
+
+
+async def test_group_mention_policy_drops_unmentioned():
+    channel, bus, transport = _make_channel()
+    await channel.start()
+    await transport.push_inbound(_inbound(is_group=True, mention=False))
+    assert bus.inbound_size == 0
+
+
+async def test_group_mention_policy_passes_mentioned():
+    channel, bus, transport = _make_channel()
+    await channel.start()
+    await transport.push_inbound(_inbound(is_group=True, mention=True))
+    assert bus.inbound_size == 1
+
+
+async def test_group_open_policy_passes_unmentioned():
+    config = _make_config(group_policy="open")
+    channel, bus, transport = _make_channel(config=config)
+    await channel.start()
+    await transport.push_inbound(_inbound(is_group=True, mention=False))
+    assert bus.inbound_size == 1
+
+
+async def test_group_reply_to_bot_passes():
+    channel, bus, transport = _make_channel()
+    await channel.start()
+    await transport.push_inbound(_inbound(is_group=True, reply_bot=True))
+    assert bus.inbound_size == 1
+
+
+async def test_wildcard_allowlist_lets_anyone_in():
+    config = _make_config(allow_from=["*"])
+    channel, bus, transport = _make_channel(config=config)
+    await channel.start()
+    await transport.push_inbound(_inbound(sender="random-user"))
+    assert bus.inbound_size == 1
+
+
+# ---------------------------------------------------------------------------
+# Reactions
+# ---------------------------------------------------------------------------
+
+
+async def test_reaction_added_on_inbound_and_removed_on_send():
+    channel, _, transport = _make_channel()
+    await channel.start()
+    await transport.push_inbound(_inbound(message_id="42"))
+    assert ("chat-1", "42") in transport.outstanding_reactions
+
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="chat-1", content="response",
+        metadata={"message_id": "42"},
+    ))
+    assert ("chat-1", "42") not in transport.outstanding_reactions
+    assert "remove_reaction" in transport.methods_called()
+
+
+async def test_reaction_not_removed_for_progress_messages():
+    channel, _, transport = _make_channel()
+    await channel.start()
+    await transport.push_inbound(_inbound(message_id="42"))
+
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="chat-1", content="thinking...",
+        metadata={"message_id": "42", "_progress": True},
+    ))
+    assert ("chat-1", "42") in transport.outstanding_reactions
+
+
+async def test_reaction_skipped_when_no_emoji_configured():
+    config = _make_config(react_emoji=None)
+    channel, _, transport = _make_channel(config=config)
+    await channel.start()
+    await transport.push_inbound(_inbound())
+    assert "add_reaction" not in transport.methods_called()
+
+
+# ---------------------------------------------------------------------------
+# Media-group buffering
+# ---------------------------------------------------------------------------
+
+
+async def test_media_group_coalesces_into_single_dispatch():
+    profile = _make_profile(media_group_buffer_ms=10)
+    channel, bus, transport = _make_channel(profile=profile)
+    await channel.start()
+
+    # Three album items sharing a media_group_id
+    for i in range(3):
+        await transport.push_inbound(_inbound(
+            content=f"caption-{i}" if i == 0 else "",
+            media=[f"/tmp/img-{i}.jpg"],
+            media_group_id="album-A",
+            message_id=str(100 + i),
+        ))
+
+    # Wait past the buffer window
+    await asyncio.sleep(0.05)
+    assert bus.inbound_size == 1
+    msg = await bus.consume_inbound()
+    assert msg.content == "caption-0"
+    assert msg.media == ["/tmp/img-0.jpg", "/tmp/img-1.jpg", "/tmp/img-2.jpg"]
+    # Only the first event triggered the inbound reaction.
+    add_reactions = [c for c in transport.calls if c.method == "add_reaction"]
+    assert len(add_reactions) == 1
+
+
+# ---------------------------------------------------------------------------
+# Outbound — chunking, media, reply/thread, render
+# ---------------------------------------------------------------------------
+
+
+async def test_outbound_text_chunked_when_over_max_len():
+    profile = _make_profile(max_message_len=10)
+    channel, _, transport = _make_channel(profile=profile)
+    await channel.start()
+
+    long_text = "abcdefghij" * 4  # 40 chars / max 10
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="c-9", content=long_text, metadata={},
+    ))
+    sends = [c for c in transport.calls if c.method == "send_text"]
+    assert len(sends) == 4
+    for s in sends:
+        assert len(s.kwargs["text"]) <= 10
+
+
+async def test_outbound_media_dispatched_with_inferred_kind():
+    channel, _, transport = _make_channel()
+    await channel.start()
+
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="c-1", content="",
+        media=["/tmp/x.jpg", "/tmp/x.ogg", "/tmp/x.bin"],
+        metadata={},
+    ))
+    media_calls = [c for c in transport.calls if c.method == "send_media"]
+    assert [c.kwargs["kind"] for c in media_calls] == ["photo", "voice", "document"]
+
+
+async def test_outbound_propagates_reply_and_thread():
+    channel, _, transport = _make_channel()
+    await channel.start()
+
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="c-1", content="hi",
+        metadata={"message_id": "55", "message_thread_id": "topic-9"},
+    ))
+    send = next(c for c in transport.calls if c.method == "send_text")
+    assert send.kwargs["reply_to"] == VendorMessageRef(chat_id="c-1", message_id="55")
+    assert send.kwargs["thread_id"] == "topic-9"
+
+
+async def test_tool_hint_uses_render_quote():
+    transport = RecordingTransport(render_quote_prefix="QUOTE> ")
+    channel, _, transport = _make_channel(transport=transport)
+    await channel.start()
+
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="c-1", content="Running tool foo",
+        metadata={"_tool_hint": True},
+    ))
+    send = next(c for c in transport.calls if c.method == "send_text")
+    assert send.kwargs["text"].startswith("QUOTE> ")
+
+
+# ---------------------------------------------------------------------------
+# Streaming buffer
+# ---------------------------------------------------------------------------
+
+
+async def test_streaming_first_delta_sends_then_subsequent_edits():
+    channel, _, transport = _make_channel()
+    await channel.start()
+
+    await channel.send_delta("c-1", "hello", metadata={"_stream_id": "s1"})
+    await channel.send_delta("c-1", " world", metadata={"_stream_id": "s1"})
+
+    sends = [c for c in transport.calls if c.method == "send_text"]
+    edits = [c for c in transport.calls if c.method == "edit_text"]
+    assert len(sends) == 1
+    assert len(edits) == 1
+    # Edit carries the accumulated text, not just the delta.
+    assert "hello world" in edits[0].kwargs["text"]
+
+
+async def test_streaming_throttles_edits():
+    profile = _make_profile(stream_edit_interval=10.0)  # never expires within test
+    channel, _, transport = _make_channel(profile=profile)
+    await channel.start()
+
+    await channel.send_delta("c-1", "a", metadata={"_stream_id": "s1"})
+    await channel.send_delta("c-1", "b", metadata={"_stream_id": "s1"})
+    await channel.send_delta("c-1", "c", metadata={"_stream_id": "s1"})
+
+    edits = [c for c in transport.calls if c.method == "edit_text"]
+    assert edits == []  # throttled out
+
+
+async def test_streaming_end_finalises_with_full_text():
+    channel, _, transport = _make_channel()
+    await channel.start()
+
+    await channel.send_delta("c-1", "partial", metadata={"_stream_id": "s1"})
+    await channel.send_delta("c-1", "", metadata={"_stream_id": "s1", "_stream_end": True})
+
+    edits = [c for c in transport.calls if c.method == "edit_text"]
+    # Two edits: throttled-bypass from second delta, then final from end.
+    final_edit = edits[-1]
+    assert "partial" in final_edit.kwargs["text"]
+    assert "c-1" not in channel._stream_bufs
+
+
+async def test_streaming_end_with_overlong_text_chunks_remainder():
+    profile = _make_profile(max_message_len=5, stream_edit_interval=0.0)
+    channel, _, transport = _make_channel(profile=profile)
+    await channel.start()
+
+    await channel.send_delta("c-1", "hello", metadata={"_stream_id": "s1"})
+    await channel.send_delta("c-1", "", metadata={"_stream_id": "s1", "_stream_end": True})
+
+    # First chunk replaces the streamed message via edit; remainder go via
+    # send_text. With "hello" (5 chars) plus extra chunks we need len > 5.
+    # Re-run with longer text:
+    channel._stream_bufs.clear()
+    transport.calls.clear()
+
+    await channel.send_delta("c-1", "abcdefghij", metadata={"_stream_id": "s2"})
+    await channel.send_delta("c-1", "", metadata={"_stream_id": "s2", "_stream_end": True})
+
+    sends = [c for c in transport.calls if c.method == "send_text"]
+    edits = [c for c in transport.calls if c.method == "edit_text"]
+    # Initial send_text on first delta; final edit on end; one extra
+    # send_text for the chunked remainder.
+    assert len(sends) == 2
+    assert len(edits) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Retry
+# ---------------------------------------------------------------------------
+
+
+async def test_send_retries_then_succeeds():
+    transport = RecordingTransport()
+    transport.fail_next("send_text", RuntimeError("boom"))
+    channel, _, _ = _make_channel(transport=transport)
+    await channel.start()
+
+    await channel.send(OutboundMessage(
+        channel="base", chat_id="c-1", content="hi", metadata={},
+    ))
+    sends = [c for c in transport.calls if c.method == "send_text"]
+    assert len(sends) == 2  # first failed, second succeeded
+
+
+async def test_send_retries_exhaust_and_raise():
+    profile = _make_profile(send_retries=2)
+    transport = RecordingTransport()
+    transport.fail_next("send_text", RuntimeError("boom-1"))
+    transport.fail_next("send_text", RuntimeError("boom-2"))
+
+    channel, _, _ = _make_channel(profile=profile, transport=transport)
+    await channel.start()
+
+    with pytest.raises(RuntimeError, match="boom-2"):
+        await channel.send(OutboundMessage(
+            channel="base", chat_id="c-1", content="hi", metadata={},
+        ))
+
+
+# ---------------------------------------------------------------------------
+# supports_streaming wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_supports_streaming_requires_config_and_profile():
+    # config.streaming=False
+    channel, _, _ = _make_channel(config=_make_config(streaming=False))
+    assert channel.supports_streaming is False
+
+    # profile.supports_edit=False
+    no_edit_profile = _make_profile()
+    no_edit_profile = ChatProfile(
+        max_message_len=no_edit_profile.max_message_len,
+        stream_edit_interval=no_edit_profile.stream_edit_interval,
+        media_group_buffer_ms=no_edit_profile.media_group_buffer_ms,
+        typing_indicator_interval=no_edit_profile.typing_indicator_interval,
+        send_retries=no_edit_profile.send_retries,
+        send_retry_base_delay=no_edit_profile.send_retry_base_delay,
+        supports_edit=False,
+    )
+    channel, _, _ = _make_channel(profile=no_edit_profile)
+    assert channel.supports_streaming is False
+
+    # both true
+    channel, _, _ = _make_channel()
+    assert channel.supports_streaming is True
+
+
+async def test_streaming_metadata_injected_into_inbound():
+    channel, bus, transport = _make_channel()
+    await channel.start()
+
+    await transport.push_inbound(_inbound())
+    msg = await bus.consume_inbound()
+    assert msg.metadata.get("_wants_stream") is True


### PR DESCRIPTION
First of two PRs landing #20 — see issue body for the full phasing rationale.

## What this PR is

Foundation only — `ChatChannel(BaseChannel)`, `ChatProfile`, `VendorTransport` Protocol, `RecordingTransport` test adapter, plus the eight pieces of shared scaffolding from ADR-0006 implemented and unit-tested. **No production Channels migrated** — Telegram migration onto this foundation is PR-D2.

## What's in `app/channels/chat/`

| File | Purpose |
|------|---------|
| `profile.py` | `ChatProfile` dataclass — vendor knobs (max_message_len, stream_edit_interval, media_group_buffer_ms, typing_indicator_interval, send_retries, supports_edit) |
| `transport.py` | `VendorTransport` Protocol + `VendorMessageRef` + `ChatInbound` + `MediaKind` literal |
| `channel.py` | `ChatChannel` — the shared scaffolding |
| `recording.py` | `RecordingTransport` — in-memory test adapter |
| `__init__.py` | Public exports |

## The eight scaffolding pieces

1. **Allowlist + group-policy gating** — reuses `BaseChannel.is_allowed`; adds `group_policy` (`open` / `mention`) layered on top
2. **Reaction lifecycle** — adds emoji on inbound, removes on the final (non-progress) response; opaque token so vendors that need a reaction id (Feishu) and vendors that don't (Telegram) share the same code path
3. **Typing indicator loop** — per-chat task with configurable interval; cancelled on send completion
4. **Media-group buffer** — debounce-coalesces album items into one bus dispatch (Telegram, Feishu); transports without media groups set `media_group_buffer_ms=0`
5. **Streaming buffer with edit-throttle** — first delta sends, subsequent deltas edit in place; final `_stream_end` flushes; chunks remainder when the stream exceeds `max_message_len`
6. **Text chunking** — outbound longer than `max_message_len` is split via the existing `split_message` helper
7. **Send retry with exponential backoff** — every transport call wrapped; `send_retries` attempts starting at `send_retry_base_delay`
8. **Lifecycle** — `start()` hands transport an inbound callback; `stop()` cancels typing tasks, flushes pending media-group buffers, tears down transport

## Why structural Protocol, not abstract base

`VendorTransport` is `typing.Protocol` (`runtime_checkable`). Vendors implement structurally — no inheritance chain, no metaclass surprises, just "implement these methods on a class." This matches ADR-0006's "composition not subclassing" framing and keeps the surface narrow.

## Why opaque reaction tokens

Vendors track reactions differently:
- Feishu's `add_reaction` returns a `reaction_id` that `remove_reaction` needs
- Slack's `reactions_add` keys removal off the emoji name
- Telegram has no token — removal is `set_message_reaction(chat, message, reaction=[])`

Modelling this with one method signature would force a least-common-denominator (e.g. always pass emoji name to `remove_reaction`) and lose Feishu's actual handle. Instead `add_reaction` returns `Any`, `remove_reaction` accepts the same opaque token. Each transport stores what it needs.

## Verification

- 24 new tests in `tests/test_channels/test_chat_channel.py` — each scaffolding piece exercised in isolation through `RecordingTransport` (no vendor SDK in the loop). Coverage: lifecycle, allowlist, all three group-policy paths (mention drop, mention pass, open + reply-to-bot pass), reaction lifecycle (add / remove on final / skip on progress / skip when emoji unset), media-group coalescing, text chunking, media kind inference, reply/thread propagation, tool-hint `render_quote` routing, streaming (first delta sends, throttled edits, end finalisation, end with chunked remainder), retry success, retry exhaustion, `supports_streaming` gating, `_wants_stream` metadata injection.
- Full suite: **787 passed / 20 skipped** (baseline 763 + 24 new).

## What ships in PR-D2

- `TelegramTransport` — the vendor half (auth, polling lifecycle, send/edit/upload via `python-telegram-bot`, markdown→HTML, mention parsing, media download)
- `TelegramChannel` — thin composer over `ChatChannel` + `TelegramTransport`
- End-to-end test: inbound Telegram update → MessageBus → outbound Part round-trip
- Net delta: -600 LOC (`telegram.py` shrinks dramatically once scaffolding is gone)

Refs #20, ADR-0006. Unblocks #67 (channel umbrella) once D2 lands.