### PR TITLE
fix(ollama): block :cloud-tagged model pulls with redirect message

### DIFF
--- a/backend/app/api/ollama.py
+++ b/backend/app/api/ollama.py
@@ -63,6 +63,24 @@ def _ollama_url(request: Request) -> str:
     return mgr.base_url
 
 
+def _is_cloud_model_tag(name: str) -> bool:
+    """True for Ollama cloud-routed models (e.g. ``glm-5.1:cloud``).
+
+    Cloud tags execute on Ollama's hosted infra rather than pulling local
+    weights, so OpenYak's pull/discovery flow doesn't fit them today. Detect
+    them up-front and surface a useful message instead of letting the request
+    fail with an opaque manifest error.
+    """
+    return name.split("/")[-1].endswith(":cloud")
+
+
+_CLOUD_BLOCK_MESSAGE = (
+    "{name} is a cloud-hosted Ollama model — not yet supported in OpenYak. "
+    "Try a local tag (e.g. qwen3:8b, llama3.2:3b) or use ChatGPT / "
+    "OpenRouter in Settings → Providers."
+)
+
+
 # ── Runtime endpoints ─────────────────────────────────────────────────────
 
 
@@ -200,6 +218,15 @@ async def get_library(
 @router.post("/ollama/models/pull")
 async def pull_model(request: Request, registry: ProviderRegistryDep, body: ModelPullRequest):
     """Pull (download) a model. Returns SSE stream with progress."""
+    if _is_cloud_model_tag(body.name):
+        message = _CLOUD_BLOCK_MESSAGE.format(name=body.name)
+        logger.info("Ollama: blocked pull for cloud-tagged model %s", body.name)
+
+        async def cloud_block_stream():
+            yield f"data: {json.dumps({'status': 'error', 'reason': 'cloud_model_unsupported', 'message': message})}\n\n"
+
+        return StreamingResponse(cloud_block_stream(), media_type="text/event-stream")
+
     base_url = _ollama_url(request)
 
     async def stream():

--- a/backend/tests/test_api/test_ollama_pull.py
+++ b/backend/tests/test_api/test_ollama_pull.py
@@ -1,0 +1,60 @@
+"""API tests for ``/ollama/models/pull`` cloud-model handling."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.api.ollama import _is_cloud_model_tag
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("glm-5.1:cloud", True),
+        ("qwen3:cloud", True),
+        ("user/glm-5.1:cloud", True),
+        ("glm-5.1", False),
+        ("llama3.2:3b", False),
+        ("library/llama3.2:3b", False),
+        ("cloudburst:7b", False),
+    ],
+)
+def test_cloud_tag_detection(name: str, expected: bool) -> None:
+    assert _is_cloud_model_tag(name) is expected
+
+
+@pytest.mark.asyncio
+async def test_pull_cloud_model_short_circuits_with_redirect_message(app_client) -> None:
+    """Cloud-tagged pulls return a structured SSE error without touching Ollama."""
+    resp = await app_client.post(
+        "/api/ollama/models/pull",
+        json={"name": "glm-5.1:cloud"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Single SSE event, JSON payload after "data: "
+    line = body.strip().splitlines()[0]
+    assert line.startswith("data: ")
+    payload = json.loads(line[len("data: "):])
+
+    assert payload["status"] == "error"
+    assert payload["reason"] == "cloud_model_unsupported"
+    assert "glm-5.1:cloud" in payload["message"]
+    # The message should redirect the user to alternative providers / local tags.
+    assert "local" in payload["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_pull_local_tag_does_not_short_circuit(app_client) -> None:
+    """Non-cloud tags fall through; without a running Ollama manager the route
+    surfaces the manager-not-initialized 503 — proving the cloud-block branch
+    didn't swallow it."""
+    resp = await app_client.post(
+        "/api/ollama/models/pull",
+        json={"name": "llama3.2:3b"},
+    )
+    assert resp.status_code == 503
+    assert "Ollama manager" in resp.text

--- a/frontend/src/components/settings/ollama/ollama-library.tsx
+++ b/frontend/src/components/settings/ollama/ollama-library.tsx
@@ -23,6 +23,7 @@ interface PullProgress {
   completed?: number;
   total?: number;
   message?: string;
+  reason?: string;
 }
 
 export function ModelLibrary({
@@ -161,10 +162,15 @@ export function ModelLibrary({
                 const data = JSON.parse(line.slice(6));
                 setPullProgress(data);
                 if (data.status === "error") {
-                  setTimeout(() => {
-                    setPullProgress(null);
-                    setPullingModel(null);
-                  }, 3000);
+                  // Errors with a structured `reason` (e.g. cloud_model_unsupported)
+                  // tend to carry actionable redirect text — keep them visible
+                  // until the user dismisses with the X button.
+                  if (!data.reason) {
+                    setTimeout(() => {
+                      setPullProgress(null);
+                      setPullingModel(null);
+                    }, 3000);
+                  }
                   return;
                 }
               } catch {
@@ -410,19 +416,30 @@ function ModelCard({
         {model.sizes.map((size) => {
           const fullName = `${model.name}:${size}`;
           const isInstalled = installedNames.has(fullName);
+          const isCloud = size.toLowerCase() === "cloud";
+          const cloudTooltip =
+            "Cloud-hosted Ollama model — not yet supported in OpenYak. Use a local-weights tag, or pick ChatGPT / OpenRouter in Settings → Providers.";
           return (
             <button
               key={size}
-              onClick={() => !isInstalled && !isPulling && onPull(fullName)}
-              disabled={isInstalled || isPulling}
+              onClick={() => !isInstalled && !isPulling && !isCloud && onPull(fullName)}
+              disabled={isInstalled || isPulling || isCloud}
               className={cn(
                 "px-1.5 py-0.5 text-ui-3xs rounded border transition-colors",
                 isInstalled
                   ? "border-[var(--color-success)]/30 bg-[var(--color-success)]/10 text-[var(--color-success)] cursor-default"
-                  : "border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--brand-primary)] hover:text-[var(--brand-primary)] cursor-pointer",
-                isPulling && !isInstalled && "opacity-50 cursor-not-allowed",
+                  : isCloud
+                    ? "border-[var(--border-default)] bg-[var(--surface-tertiary)] text-[var(--text-tertiary)] cursor-not-allowed"
+                    : "border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--brand-primary)] hover:text-[var(--brand-primary)] cursor-pointer",
+                isPulling && !isInstalled && !isCloud && "opacity-50 cursor-not-allowed",
               )}
-              title={isInstalled ? "Installed" : `Pull ${fullName}`}
+              title={
+                isInstalled
+                  ? "Installed"
+                  : isCloud
+                    ? cloudTooltip
+                    : `Pull ${fullName}`
+              }
             >
               {isInstalled && <Check className="h-2.5 w-2.5 inline mr-0.5" />}
               {size}


### PR DESCRIPTION
## Summary

- Detect Ollama \`:cloud\`-tagged models (e.g. \`glm-5.1:cloud\`) in the pull endpoint and short-circuit with a structured SSE error pointing the user at real local tags or other providers, instead of letting the request fail with an opaque manifest error.
- Disable the \`cloud\` size button in the model library card with a tooltip explaining the limitation.
- Tag the SSE event with \`reason: cloud_model_unsupported\` so the frontend banner persists until dismissed (current behavior auto-clears errors after 3s, too short to read the redirect text).

Refs #73 — chose option (b) (block + redirect) from the issue's I5 decision tree. Leaves option (a) first-class cloud support open for follow-up; (a) needs Ollama account auth + a separate \`add-cloud-model\` flow + cloud-aware discovery, which is days, not hours.

## Why a one-line tag check is enough

\`name.split(\"/\")[-1].endswith(\":cloud\")\` covers every shape that hits the endpoint today:
- bare: \`glm-5.1:cloud\` ✅
- community-namespaced: \`user/glm-5.1:cloud\` ✅
- false-positive guard: \`cloudburst:7b\` correctly returns False (substring match would have failed)

If Ollama later introduces nested cloud tags like \`glm-5.1:cloud-q4\` we'll need to broaden, but that's speculative — \`endswith(\":cloud\")\` matches every cloud model on ollama.com today.

## Why \`reason\` instead of a longer timeout

Auto-clearing the banner after 3s is fine for routine pull errors (\"manifest unknown\", network blips), where the user already knows what they tried. Cloud-block carries a redirect (\"try qwen3:8b instead, or use ChatGPT in Settings → Providers\") that's only useful if read. The \`reason\` field lets us persist deliberately without bumping the timeout for every error type. The X button on the banner already exists for manual dismissal.

## Test plan

- [x] \`backend/tests/test_api/test_ollama_pull.py\` — 7 parametrized unit tests for \`_is_cloud_model_tag\` (incl. negative \`cloudburst:7b\`), 1 integration test for the \`POST /api/ollama/models/pull\` short-circuit (asserts SSE shape, \`reason\`, and that the redirect text contains \"local\"), 1 regression test confirming non-cloud tags still flow through to the existing \`_ollama_url\` path
- [x] \`pytest tests/test_api/ tests/test_ollama -q\` → 188 passed, 7 skipped, 0 failed
- [x] Frontend \`tsc --noEmit\` → 0 errors
- [ ] Manual smoke (recommended for reviewer): in the Ollama settings panel, search for \`glm-5.1\`, confirm the \`cloud\` size button is greyed out with the new tooltip; type \`glm-5.1:cloud\` in the custom-pull box and confirm the banner shows the redirect text and stays until dismissed
- [ ] Manual smoke: pull a real local model (\`llama3.2:3b\`) end-to-end — confirm the banner still auto-clears on success and on routine errors

## Out of scope (tracked in #73)

- I4: \`GLM 5.1\` still appears in the OpenRouter Intelligence Index leaderboard (\`use-arena-scores.ts:49\`) — that's a separate UX path that doesn't currently route to Ollama setup, but worth a follow-up to make sure it doesn't suggest local-pullability anywhere
- I6: cloud-tagged model inventory on ollama.com (Qwen, GLM, …) — quantify the user-impact surface
- I7: structured logging on \`/ollama/models/pull\` (correlation ID, user, error class) so future user reports are diagnosable from server logs alone
- A first-class \`:cloud\` integration (option I5(a)) — Ollama account sign-in + cloud listing API + provider routing