### PR TITLE
Resolve context window and image input issues

### DIFF
--- a/.dev/fixes/_index.md
+++ b/.dev/fixes/_index.md
@@ -8,7 +8,7 @@
 (empty)
 
 ### session
-(empty)
+- [Context window limited to about 43k on long-context models](session/context-window-limited-to-43k.md)
 
 ### tool
 (empty)
@@ -24,6 +24,7 @@
 
 ### frontend
 - [dev:all browser UI shows no models and API requests return 401](frontend/dev-all-web-ui-api-401.md)
+- [Image attachments ignored by non-vision models](frontend/image-attachments-ignored-by-non-vision-models.md)
 
 ### desktop
 (empty)
@@ -46,3 +47,5 @@
 | Click handler fires twice | `useState` guard vs `useRef` guard | Switch to `useRef` for sync guard | (add record) |
 | Startup crash — one bad plugin | Missing try-catch in init loop | Wrap per-item in try-catch | (add record) |
 | dev:all browser UI shows no models / API 401 | Web dev proxy missing session token | Run through `scripts/dev-all.mjs` dev token bridge | [record](frontend/dev-all-web-ui-api-401.md) |
+| Context window is about 43k on 128k+ models | Synthetic `effective_context_window` default | Use raw model context unless provider sets explicit override | [record](session/context-window-limited-to-43k.md) |
+| Image attachment is ignored or guessed | Non-vision model received stripped image content | Block image input unless selected model is explicitly vision-capable | [record](frontend/image-attachments-ignored-by-non-vision-models.md) |

--- a/.dev/fixes/frontend/image-attachments-ignored-by-non-vision-models.md
+++ b/.dev/fixes/frontend/image-attachments-ignored-by-non-vision-models.md
@@ -1,0 +1,16 @@
+# Image attachments ignored by non-vision models
+**Status**: active | **Created**: 2026-05-09 | **Tags**: frontend, provider, vision, attachments
+
+## Symptoms
+Attaching an image and asking what the assistant sees can produce a text-only answer where the model did not actually receive the image. Providing an image path can also lead the model to guess image contents.
+
+## Root Cause
+Image content was silently stripped for models whose metadata did not mark them as vision-capable, and OpenRouter vision detection did not read `architecture.input_modalities`.
+
+## Fix
+Detect OpenRouter vision support from `architecture.input_modalities`, block image sends for non-vision or unknown models in the frontend and backend, and stop tool/image handoff with a clear `MODEL_DOES_NOT_SUPPORT_IMAGES` error instead of stripping image blocks.
+
+## Prevention
+- [x] Test added? `backend/tests/test_provider/test_openrouter.py`, `backend/tests/test_session/test_utils.py`
+- [x] Lint catches it? TypeScript checks cover the frontend request shape.
+- [ ] Gotcha updated?

--- a/.dev/fixes/session/context-window-limited-to-43k.md
+++ b/.dev/fixes/session/context-window-limited-to-43k.md
@@ -1,0 +1,16 @@
+# Context window limited to about 43k on long-context models
+**Status**: active | **Created**: 2026-05-09 | **Tags**: session, compaction, context-window
+
+## Symptoms
+Models advertised with large context windows, such as 128k or 256k, compact or truncate much earlier than expected. A 128k model can appear limited to roughly 43k tokens.
+
+## Root Cause
+The provider registry auto-derived `effective_context_window` for every model as 33% of the advertised context window, so compaction and UI usage were based on a reduced synthetic limit.
+
+## Fix
+Use the model's full advertised context by default, keep `effective_context_window` only for explicit provider overrides, and trigger compaction at 90% of usable context after output and reserve budgets are subtracted.
+
+## Prevention
+- [x] Test added? `backend/tests/test_session/test_utils.py`, `backend/tests/test_session/test_compaction.py`
+- [ ] Lint catches it?
+- [ ] Gotcha updated?

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -30,6 +30,10 @@ from app.session.compaction import run_compaction
 from app.session.manager import get_session
 from app.session.manager import delete_messages_after, update_message_file_parts, update_message_text
 from app.session.processor import run_generation
+from app.session.utils import (
+    compute_usable_context_window,
+    get_effective_context_window,
+)
 from app.streaming.events import AGENT_ERROR, COMPACTION_ERROR, DONE, PERMISSION_RESOLVED, QUESTION_RESOLVED, SSEEvent
 from app.streaming.manager import GenerationJob, StreamManager
 from app.utils.id import generate_ulid
@@ -89,13 +93,12 @@ async def _get_session_context_usage_ratio(
         return None
 
     _provider, model_info = resolved
-    effective_context = model_info.metadata.get("effective_context_window") if model_info.metadata else None
-    max_context = (
-        min(effective_context, model_info.capabilities.max_context)
-        if isinstance(effective_context, (int, float)) and effective_context > 0
-        else model_info.capabilities.max_context
+    max_context = get_effective_context_window(model_info) or model_info.capabilities.max_context
+    context_limit = compute_usable_context_window(
+        max_context,
+        model_max_output=model_info.capabilities.max_output,
     )
-    if not max_context or max_context <= 0:
+    if not context_limit or context_limit <= 0:
         return None
 
     async with session_factory() as db:
@@ -118,7 +121,7 @@ async def _get_session_context_usage_ratio(
         cache_read = int(tokens.get("cache_read", 0) or 0)
         total_tokens = input_tokens + cache_read
         if total_tokens > 0:
-            return total_tokens / max_context
+            return total_tokens / context_limit
     return 0.0
 
 

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -33,6 +33,7 @@ from app.session.processor import run_generation
 from app.session.utils import (
     compute_usable_context_window,
     get_effective_context_window,
+    has_image_attachments,
 )
 from app.streaming.events import AGENT_ERROR, COMPACTION_ERROR, DONE, PERMISSION_RESOLVED, QUESTION_RESOLVED, SSEEvent
 from app.streaming.manager import GenerationJob, StreamManager
@@ -43,9 +44,43 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _MANUAL_COMPACTION_MIN_USAGE_RATIO = 0.5
+MODEL_DOES_NOT_SUPPORT_IMAGES = "MODEL_DOES_NOT_SUPPORT_IMAGES"
 
 # Heartbeat interval (seconds) — prevents proxy/CDN timeout
 _HEARTBEAT_INTERVAL = 15.0
+
+
+def _unsupported_images_error() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail={
+            "code": MODEL_DOES_NOT_SUPPORT_IMAGES,
+            "message": "The selected model does not support images. Choose a vision model and try again.",
+        },
+    )
+
+
+def _ensure_image_attachments_supported(
+    *,
+    attachments: list[dict[str, Any]] | None,
+    provider_registry,
+    model_id: str | None,
+    provider_id: str | None,
+) -> None:
+    """Reject image inputs unless the requested model is explicitly vision-capable."""
+    if not has_image_attachments(attachments):
+        return
+
+    if not model_id:
+        raise _unsupported_images_error()
+
+    resolved = provider_registry.resolve_model(model_id, provider_id)
+    if resolved is None:
+        raise _unsupported_images_error()
+
+    _provider, model_info = resolved
+    if not model_info.capabilities.vision:
+        raise _unsupported_images_error()
 
 
 def _on_task_done(task: asyncio.Task[None], *, job: GenerationJob) -> None:
@@ -136,6 +171,13 @@ async def start_prompt(
     index_manager: IndexManagerDep,
 ) -> PromptResponse:
     """Start a new generation. Returns stream_id for SSE subscription."""
+    _ensure_image_attachments_supported(
+        attachments=body.attachments,
+        provider_registry=provider_registry,
+        model_id=body.model,
+        provider_id=body.provider_id,
+    )
+
     session_id = body.session_id or generate_ulid()
     stream_id = generate_ulid()
 
@@ -262,6 +304,13 @@ async def edit_and_resend(
     index_manager: IndexManagerDep,
 ) -> PromptResponse:
     """Edit a user message, delete all subsequent messages, and re-generate."""
+    _ensure_image_attachments_supported(
+        attachments=body.attachments,
+        provider_registry=provider_registry,
+        model_id=body.model,
+        provider_id=body.provider_id,
+    )
+
     stream_id = generate_ulid()
 
     # Atomic DB operation: update message text + delete subsequent messages
@@ -283,6 +332,7 @@ async def edit_and_resend(
         session_id=body.session_id,
         text=body.text,
         model=body.model,
+        provider_id=body.provider_id,
         agent=body.agent,
         attachments=body.attachments,
         permission_presets=body.permission_presets,

--- a/backend/app/provider/openrouter.py
+++ b/backend/app/provider/openrouter.py
@@ -40,6 +40,17 @@ def _is_free(pricing: dict) -> bool:
     return float(pricing.get("prompt", "1")) == 0 and float(pricing.get("completion", "1")) == 0
 
 
+def _architecture_supports_vision(architecture: dict) -> bool:
+    input_modalities = architecture.get("input_modalities")
+    if isinstance(input_modalities, list) and "image" in input_modalities:
+        return True
+    if isinstance(input_modalities, str) and "image" in input_modalities:
+        return True
+
+    modality = architecture.get("modality", "")
+    return isinstance(modality, str) and "image" in modality
+
+
 class OpenRouterProvider(OpenAICompatProvider):
     """OpenRouter LLM provider with reasoning support."""
 
@@ -132,7 +143,7 @@ class OpenRouterProvider(OpenAICompatProvider):
 
             # Detect capabilities from model metadata
             architecture = m.get("architecture", {})
-            modality = architecture.get("modality", "")
+            has_vision = _architecture_supports_vision(architecture)
 
             # Detect caching support based on model family
             supports_caching = False
@@ -152,7 +163,7 @@ class OpenRouterProvider(OpenAICompatProvider):
                     provider_id=self._provider_id,
                     capabilities=ModelCapabilities(
                         function_calling="tool" in str(m.get("supported_parameters", [])),
-                        vision="image" in modality,
+                        vision=has_vision,
                         reasoning="reasoning" in model_id.lower()
                         or "think" in model_id.lower()
                         or "r1" in model_id.lower(),

--- a/backend/app/provider/registry.py
+++ b/backend/app/provider/registry.py
@@ -7,8 +7,6 @@ import logging
 
 from app.provider.base import BaseProvider
 from app.schemas.provider import ModelInfo, ProviderStatus
-from app.session.utils import compute_effective_context_window
-
 logger = logging.getLogger(__name__)
 
 MODEL_REFRESH_TIMEOUT_SECONDS = 45.0
@@ -81,15 +79,6 @@ class ProviderRegistry:
 
             result[pid] = models
             for m in models:
-                metadata = dict(m.metadata or {})
-                effective = compute_effective_context_window(
-                    m.capabilities.max_context,
-                    metadata.get("effective_context_window"),
-                )
-                if effective is not None:
-                    metadata["effective_context_window"] = effective
-                    m.metadata = metadata
-
                 # Full list keeps everything (including duplicates)
                 new_full.append((provider, m))
 

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -44,6 +44,7 @@ class EditAndResendRequest(BaseModel):
     message_id: str  # The user message to edit
     text: str  # New text content
     model: str | None = None
+    provider_id: str | None = None
     agent: str = "build"
     attachments: list[dict[str, Any]] = []
     permission_presets: dict[str, bool] | None = None

--- a/backend/app/session/compaction.py
+++ b/backend/app/session/compaction.py
@@ -35,8 +35,9 @@ from app.streaming.events import (
 from app.streaming.manager import GenerationJob
 from app.utils.token import estimate_tokens
 
-# Re-use cost calculation from session utils
+# Re-use cost/budget helpers from session utils
 from app.session.utils import calculate_step_cost as _calculate_step_cost
+from app.session.utils import compute_usable_context_window
 
 logger = logging.getLogger(__name__)
 
@@ -339,9 +340,10 @@ def should_compact(
 ) -> bool:
     """Check if context usage warrants compaction.
 
-    Mirrors OpenCode ``SessionCompaction.isOverflow()``:
+    Mirrors OpenCode ``SessionCompaction.isOverflow()`` budget shape:
       - reserved defaults to ``min(20_000, model_max_output)``
       - usable = model_max_context - output_budget - reserved
+      - auto compact starts at 90% of usable context
     """
     total_tokens = usage.get("total", 0)
     if not total_tokens:
@@ -351,9 +353,10 @@ def should_compact(
             + usage.get("reasoning", 0)
             + usage.get("cache_read", 0)
         )
-    effective_output = model_max_output or 8192
-    if reserved is None:
-        reserved = min(20_000, effective_output)
-    # Usable = total context window - output budget - safety reserve
-    usable = model_max_context - effective_output - reserved
-    return total_tokens >= usable and usable > 0
+    usable = compute_usable_context_window(
+        model_max_context,
+        model_max_output=model_max_output,
+        reserved=reserved,
+    )
+    threshold = int(usable * 0.9)
+    return total_tokens >= threshold and threshold > 0

--- a/backend/app/session/processor.py
+++ b/backend/app/session/processor.py
@@ -71,8 +71,8 @@ from app.session.utils import (
     calculate_step_cost as _calculate_step_cost,
     compute_safe_max_tokens as _compute_safe_max_tokens,
     get_effective_context_window as _get_effective_context_window,
+    llm_messages_have_image_content as _llm_messages_have_image_content,
     repair_tool_call_payload as _repair_tool_call_payload,
-    strip_image_content as _strip_image_content,
 )
 from app.utils.id import generate_ulid
 
@@ -492,11 +492,51 @@ class SessionProcessor:
                 if sp.provider.id == "ollama":
                     job.publish(SSEEvent(MODEL_LOADING, {"model": sp.model_id, "status": "loading"}))
 
-                # Strip image_url from messages if model doesn't support vision.
-                # User-attached images may have image_url content.
                 _llm_msgs = self._llm_messages
-                if sp.model_info and not sp.model_info.capabilities.vision:
-                    _llm_msgs = _strip_image_content(_llm_msgs)
+                if (
+                    sp.model_info
+                    and not sp.model_info.capabilities.vision
+                    and _llm_messages_have_image_content(_llm_msgs)
+                ):
+                    message = (
+                        "The selected model does not support images. "
+                        "Choose a vision model and try again."
+                    )
+                    logger.info(
+                        "Blocked image content for non-vision model=%s session=%s",
+                        sp.model_id,
+                        job.session_id,
+                    )
+                    job.publish(
+                        SSEEvent(
+                            AGENT_ERROR,
+                            {
+                                "error_type": "MODEL_DOES_NOT_SUPPORT_IMAGES",
+                                "error_message": message,
+                            },
+                        )
+                    )
+                    async with session_factory() as db:
+                        async with db.begin():
+                            await create_part(
+                                db,
+                                message_id=self._assistant_msg_id,
+                                session_id=job.session_id,
+                                data={"type": "text", "text": message},
+                            )
+                            await create_part(
+                                db,
+                                message_id=self._assistant_msg_id,
+                                session_id=job.session_id,
+                                data={
+                                    "type": "step-finish",
+                                    "reason": "error",
+                                    "tokens": {},
+                                    "cost": 0.0,
+                                },
+                            )
+                    self.finish_reason = "error"
+                    return "stop"
 
                 async for chunk in stream_llm(
                     sp.provider,

--- a/backend/app/session/utils.py
+++ b/backend/app/session/utils.py
@@ -25,22 +25,42 @@ CHARS_PER_TOKEN = 4  # Average characters per token for rough estimation
 MIN_RESERVED_TOKENS = 2048  # Minimum tokens reserved for system overhead
 RESERVED_CONTEXT_RATIO = 0.08  # Fraction of model context reserved for overhead
 MIN_PARTIAL_MESSAGE_CHARS = 2_048  # Smallest useful tail/head slice to preserve
-EFFECTIVE_CONTEXT_RATIO = 0.33  # Safe operating window before proactive compaction
+DEFAULT_OUTPUT_BUDGET = 8192
+
+_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"}
 
 
 def compute_effective_context_window(
     max_context: int | None,
     explicit_effective: int | None = None,
 ) -> int | None:
-    """Compute the effective context window used for UX/compaction decisions."""
+    """Compute the context window used for budgeting decisions.
+
+    Provider-specific overrides are still honored, but models without an
+    explicit override should use their advertised context window. Safety
+    margins are applied later via output/reserved budgets.
+    """
     if isinstance(explicit_effective, int) and explicit_effective > 0:
         if isinstance(max_context, int) and max_context > 0:
             return min(explicit_effective, max_context)
         return explicit_effective
 
     if isinstance(max_context, int) and max_context > 0:
-        return max(1, int(max_context * EFFECTIVE_CONTEXT_RATIO))
+        return max_context
     return None
+
+
+def compute_usable_context_window(
+    model_max_context: int,
+    *,
+    model_max_output: int | None = None,
+    reserved: int | None = None,
+) -> int:
+    """Return context available for prompt/history after output and reserve."""
+    effective_output = model_max_output or DEFAULT_OUTPUT_BUDGET
+    if reserved is None:
+        reserved = min(_cfg().compaction_reserved, effective_output)
+    return max(0, model_max_context - effective_output - reserved)
 
 
 def get_effective_context_window(model_info: Any | None) -> int | None:

--- a/backend/app/session/utils.py
+++ b/backend/app/session/utils.py
@@ -310,6 +310,40 @@ def strip_image_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return result
 
 
+def is_image_attachment(attachment: dict[str, Any]) -> bool:
+    """Return whether an attachment should be treated as image input."""
+    mime = str(attachment.get("mime_type") or attachment.get("mime") or "")
+    if mime.startswith("image/"):
+        return True
+    if attachment.get("type") == "image":
+        return True
+
+    name = str(attachment.get("name") or "")
+    path = str(attachment.get("path") or "")
+    suffix = ""
+    for value in (name, path):
+        if "." in value:
+            suffix = "." + value.rsplit(".", 1)[-1].lower()
+            break
+    return suffix in _IMAGE_EXTENSIONS
+
+
+def has_image_attachments(attachments: list[dict[str, Any]] | None) -> bool:
+    return any(is_image_attachment(att) for att in attachments or [])
+
+
+def llm_messages_have_image_content(messages: list[dict[str, Any]]) -> bool:
+    """Return whether prepared LLM messages contain multimodal image blocks."""
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "image_url":
+                return True
+    return False
+
+
 def estimate_llm_message_tokens(messages: list[dict[str, Any]]) -> int:
     total_chars = 0
     for m in messages:

--- a/backend/tests/test_provider/test_openrouter.py
+++ b/backend/tests/test_provider/test_openrouter.py
@@ -6,10 +6,22 @@ These tests require a valid OPENYAK_OPENROUTER_API_KEY in .env.
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from app.provider.openrouter import OpenRouterProvider
+from app.provider.openrouter import OpenRouterProvider, _architecture_supports_vision
 from app.provider.registry import ProviderRegistry
 from app.provider.tool_calling.detector import supports_function_calling
 from app.provider.tool_calling.prompt_based import build_tool_prompt, parse_tool_calls
+
+
+class TestOpenRouterModelMetadata:
+    def test_architecture_vision_detection_uses_input_modalities(self):
+        assert _architecture_supports_vision({
+            "input_modalities": ["text", "image"],
+            "output_modalities": ["text"],
+        })
+
+    def test_architecture_vision_detection_keeps_modality_fallback(self):
+        assert _architecture_supports_vision({"modality": "text+image->text"})
+        assert not _architecture_supports_vision({"modality": "text->text"})
 
 
 class TestOpenRouterConnection:

--- a/backend/tests/test_session/test_compaction.py
+++ b/backend/tests/test_session/test_compaction.py
@@ -12,13 +12,14 @@ class TestShouldCompact:
         usage = {"input": 120_000, "output": 5_000}
         assert should_compact(usage, model_max_context=128_000, reserved=20_000)
 
-    def test_exactly_at_threshold(self):
-        usage = {"input": 99_807, "output": 0}
+    def test_just_below_ninety_percent_threshold(self):
+        usage = {"input": 89_826, "output": 0}
         # usable = 128000 - 8192(effective_output) - 20000(reserved) = 99808
+        # threshold = int(99808 * 0.9) = 89827
         assert not should_compact(usage, model_max_context=128_000, reserved=20_000)
 
-    def test_just_over_threshold(self):
-        usage = {"input": 108_001, "output": 0}
+    def test_at_ninety_percent_threshold(self):
+        usage = {"input": 89_827, "output": 0}
         assert should_compact(usage, model_max_context=128_000, reserved=20_000)
 
     def test_empty_usage(self):

--- a/backend/tests/test_session/test_utils.py
+++ b/backend/tests/test_session/test_utils.py
@@ -6,6 +6,8 @@ from app.session.utils import (
     compute_usable_context_window,
     compute_effective_context_window,
     get_effective_context_window,
+    has_image_attachments,
+    llm_messages_have_image_content,
     sanitize_llm_messages_for_request,
 )
 
@@ -91,3 +93,23 @@ def test_usable_context_window_subtracts_output_and_reserved_budget():
         model_max_output=8_192,
         reserved=8_192,
     ) == 111_616
+
+
+def test_image_attachment_detection_covers_mime_extension_and_mobile_type():
+    assert has_image_attachments([{"name": "chart.png", "mime_type": ""}])
+    assert has_image_attachments([{"name": "upload", "mime_type": "image/jpeg"}])
+    assert has_image_attachments([{"type": "image", "path": "/tmp/no-ext"}])
+    assert not has_image_attachments([{"name": "notes.txt", "mime_type": "text/plain"}])
+
+
+def test_llm_messages_have_image_content_detects_multimodal_blocks():
+    assert llm_messages_have_image_content([
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        }
+    ])
+    assert not llm_messages_have_image_content([{"role": "user", "content": "plain"}])

--- a/backend/tests/test_session/test_utils.py
+++ b/backend/tests/test_session/test_utils.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 from app.session.utils import (
+    compute_usable_context_window,
     compute_effective_context_window,
     get_effective_context_window,
     sanitize_llm_messages_for_request,
@@ -79,5 +80,14 @@ def test_effective_context_window_is_clamped_to_max_context():
     assert get_effective_context_window(model_info) == 128_000
 
 
-def test_effective_context_window_defaults_to_thirty_three_percent():
-    assert compute_effective_context_window(200_000) == 66_000
+def test_effective_context_window_defaults_to_full_context():
+    assert compute_effective_context_window(200_000) == 200_000
+    assert compute_effective_context_window(256_000) == 256_000
+
+
+def test_usable_context_window_subtracts_output_and_reserved_budget():
+    assert compute_usable_context_window(
+        128_000,
+        model_max_output=8_192,
+        reserved=8_192,
+    ) == 111_616

--- a/frontend/src/app/(mobile)/m/new/page.tsx
+++ b/frontend/src/app/(mobile)/m/new/page.tsx
@@ -11,6 +11,8 @@ import { useProviderModels } from "@/hooks/use-provider-models";
 import { useSettingsStore } from "@/stores/settings-store";
 import { MobileDirectoryBrowser } from "@/components/mobile/directory-browser";
 
+const VISION_MODEL_REQUIRED_MESSAGE = "The selected model does not support images. Choose a vision model and try again.";
+
 /**
  * Mobile new task page.
  *
@@ -66,6 +68,11 @@ export default function MobileNewTaskPage() {
 
   const handleSubmit = useCallback(async () => {
     if (!text.trim() || sending) return;
+    const selectedModelInfo = models.find((model) => model.id === selectedModel);
+    if (files.some((file) => file.type.startsWith("image/")) && selectedModelInfo?.capabilities.vision !== true) {
+      toast.error(VISION_MODEL_REQUIRED_MESSAGE);
+      return;
+    }
     setSending(true);
 
     try {
@@ -112,7 +119,7 @@ export default function MobileNewTaskPage() {
       toast.error("Failed to send task. Check your connection.");
       setSending(false);
     }
-  }, [text, sending, files, selectedModel, workspaceDirectory, router]);
+  }, [text, sending, files, models, selectedModel, workspaceDirectory, router]);
 
   // Current model name for display
   return (

--- a/frontend/src/components/chat/context-indicator.tsx
+++ b/frontend/src/components/chat/context-indicator.tsx
@@ -19,6 +19,9 @@ interface ContextIndicatorProps {
   sessionId: string;
 }
 
+const DEFAULT_OUTPUT_BUDGET = 8192;
+const DEFAULT_RESERVED_BUDGET = 20_000;
+
 function formatTokenCompact(count: number): string {
   if (count >= 1_000_000) {
     const value = count / 1_000_000;
@@ -75,11 +78,18 @@ export function ContextIndicator({ sessionId }: ContextIndicatorProps) {
   const startCompactionStream = useChatStore((s) => s.startCompactionStream);
   const selectedModelInfo = models?.find((m) => m.id === selectedModel);
   const effectiveContext = selectedModelInfo?.metadata?.effective_context_window;
-  const maxContext =
+  const rawContext = selectedModelInfo?.capabilities.max_context;
+  const budgetContext =
     typeof effectiveContext === "number" && effectiveContext > 0
-      ? Math.min(effectiveContext, selectedModelInfo?.capabilities.max_context ?? effectiveContext)
-      : selectedModelInfo?.capabilities.max_context;
-  const { data: stats } = useMessageStats(sessionId, maxContext);
+      ? Math.min(effectiveContext, rawContext ?? effectiveContext)
+      : rawContext;
+  const outputBudget = selectedModelInfo?.capabilities.max_output ?? DEFAULT_OUTPUT_BUDGET;
+  const reservedBudget = Math.min(DEFAULT_RESERVED_BUDGET, outputBudget);
+  const usableContext =
+    typeof budgetContext === "number" && budgetContext > 0
+      ? Math.max(1, budgetContext - outputBudget - reservedBudget)
+      : undefined;
+  const { data: stats } = useMessageStats(sessionId, usableContext);
   const [isStartingCompact, setIsStartingCompact] = useState(false);
   const meetsManualCompactionThreshold = !!stats && stats.percentage >= 50;
 
@@ -114,7 +124,7 @@ export function ContextIndicator({ sessionId }: ContextIndicatorProps) {
   };
 
   const usedCompact = formatTokenCompact(stats.totalTokens);
-  const limitCompact = formatTokenCompact(maxContext ?? 0);
+  const limitCompact = formatTokenCompact(rawContext ?? budgetContext ?? 0);
   const statusColor = getStatusColor();
   const isDisabled = isGenerating || isChatCompacting || isStartingCompact || !meetsManualCompactionThreshold;
   const compactHint = isGenerating

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -18,6 +18,45 @@ import type { InfiniteData } from "@tanstack/react-query";
 import type { FileAttachment, PromptResponse, RespondRequest } from "@/types/chat";
 import type { PaginatedMessages } from "@/types/message";
 import type { SessionResponse } from "@/types/session";
+import type { ModelInfo } from "@/types/model";
+
+const MODEL_DOES_NOT_SUPPORT_IMAGES = "MODEL_DOES_NOT_SUPPORT_IMAGES";
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+const VISION_MODEL_REQUIRED_MESSAGE = "The selected model does not support images. Choose a vision model and try again.";
+
+function isImageAttachment(attachment: FileAttachment): boolean {
+  if (attachment.mime_type?.startsWith("image/")) return true;
+  const source = attachment.name || attachment.path || "";
+  const dot = source.lastIndexOf(".");
+  if (dot < 0) return false;
+  return IMAGE_EXTENSIONS.has(source.slice(dot).toLowerCase());
+}
+
+function hasImageAttachments(attachments?: FileAttachment[]): boolean {
+  return !!attachments?.some(isImageAttachment);
+}
+
+function selectedModelSupportsVision(
+  models: ModelInfo[] | undefined,
+  modelId: string | null,
+  providerId: string | null,
+): boolean {
+  if (!modelId || !models) return false;
+  const selected =
+    models.find((model) => model.id === modelId && (!providerId || model.provider_id === providerId)) ??
+    models.find((model) => model.id === modelId);
+  return selected?.capabilities.vision === true;
+}
+
+function isUnsupportedImagesError(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  const detail = (err.body as { detail?: unknown } | undefined)?.detail;
+  return (
+    typeof detail === "object" &&
+    detail !== null &&
+    (detail as { code?: unknown }).code === MODEL_DOES_NOT_SUPPORT_IMAGES
+  );
+}
 
 /**
  * Core chat hook — orchestrates the full prompt → stream → assemble cycle.
@@ -55,6 +94,17 @@ export function useChat(currentSessionId?: string) {
       const settingsState = useSettingsStore.getState();
 
       if (chatState.isGenerating || chatState.isCompacting || (!text.trim() && (!attachments || attachments.length === 0))) return false;
+      if (
+        hasImageAttachments(attachments) &&
+        !selectedModelSupportsVision(
+          queryClient.getQueryData<ModelInfo[]>(queryKeys.models),
+          settingsState.selectedModel,
+          settingsState.selectedProviderId,
+        )
+      ) {
+        toast.error(VISION_MODEL_REQUIRED_MESSAGE);
+        return false;
+      }
 
       // New chat must start from a clean per-session state to avoid
       // leaking any transient stream/session context from previous chats.
@@ -152,6 +202,10 @@ export function useChat(currentSessionId?: string) {
 
         // Show upgrade prompt for billing errors (proxied from OpenYak proxy)
         if (err instanceof ApiError) {
+          if (isUnsupportedImagesError(err)) {
+            toast.error(VISION_MODEL_REQUIRED_MESSAGE);
+            return false;
+          }
           if (err.status === 429) {
             useBillingStore.getState().showUpgrade("quota_exceeded");
             return false;
@@ -230,6 +284,17 @@ export function useChat(currentSessionId?: string) {
       const settingsState = useSettingsStore.getState();
 
       if (chatState.isGenerating || chatState.isCompacting || (!newText.trim() && (!attachments || attachments.length === 0)) || !currentSessionId) return false;
+      if (
+        hasImageAttachments(attachments) &&
+        !selectedModelSupportsVision(
+          queryClient.getQueryData<ModelInfo[]>(queryKeys.models),
+          settingsState.selectedModel,
+          settingsState.selectedProviderId,
+        )
+      ) {
+        toast.error(VISION_MODEL_REQUIRED_MESSAGE);
+        return false;
+      }
 
       // Close any panels bound to the previous assistant response so resend
       // doesn't keep showing stale "done" activity while the new run is live.
@@ -324,6 +389,10 @@ export function useChat(currentSessionId?: string) {
         useChatStore.getState().reset();
 
         if (err instanceof ApiError) {
+          if (isUnsupportedImagesError(err)) {
+            toast.error(VISION_MODEL_REQUIRED_MESSAGE);
+            return false;
+          }
           if (err.status === 429) {
             useBillingStore.getState().showUpgrade("quota_exceeded");
             return false;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -15,6 +15,7 @@ export interface PromptRequest {
   session_id?: string | null;
   text: string;
   model?: string | null;
+  provider_id?: string | null;
   agent?: string;
   attachments?: FileAttachment[];
   permission_presets?: Record<string, boolean> | null;
@@ -33,6 +34,7 @@ export interface EditAndResendRequest {
   message_id: string;
   text: string;
   model?: string | null;
+  provider_id?: string | null;
   agent?: string;
   attachments?: FileAttachment[];
   permission_presets?: Record<string, boolean> | null;


### PR DESCRIPTION
## Summary
- Resolves #84 by using the model advertised context window by default, reserving output/safety budget separately, and compacting at 90% of usable context.
- Resolves #85 by requiring explicit vision capability for image attachments, improving OpenRouter vision metadata detection, and returning MODEL_DOES_NOT_SUPPORT_IMAGES instead of silently stripping images.
- Adds fix records for both bug patterns.

## Validation
- cd backend && pytest -q tests/test_session/test_utils.py tests/test_session/test_compaction.py tests/test_provider/test_openrouter.py -k 'not OpenRouterConnection'
- cd backend && python -m py_compile app/api/chat.py app/provider/openrouter.py app/provider/registry.py app/schemas/chat.py app/session/compaction.py app/session/processor.py app/session/utils.py
- cd frontend && npx tsc --noEmit

## Notes
- Full OpenRouter live stream tests were not run successfully locally because the test API key fixture resolved to a local venv python path and OpenRouter returned 401.
