### PR TITLE
[codex] Fix context window compaction threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/), and this project
 
 ## [Unreleased]
 
+### Fixed
+
+- **backend (context window):** Removed the artificial ChatGPT subscription effective context cap so models use their advertised context window by default, with proactive compaction now starting at 85% while still preserving output and safety reserves.
+
 ## [1.1.9] - 2026-04-29
 
 ### Added

--- a/backend/app/provider/openai_subscription.py
+++ b/backend/app/provider/openai_subscription.py
@@ -42,12 +42,6 @@ _SUBSCRIPTION_MODELS: list[dict[str, Any]] = [
             "max_context": 1_050_000,
             "max_output": 128_000,
         },
-        "metadata": {
-            # Same effective-window reasoning as 5.4: the advertised window is
-            # generous but Codex-style interactive sessions compact earlier.
-            # Tighten as soon as we have a measured value for 5.5 specifically.
-            "effective_context_window": 258_000,
-        },
     },
     {
         "id": "gpt-5.4",
@@ -59,12 +53,6 @@ _SUBSCRIPTION_MODELS: list[dict[str, Any]] = [
             "json_output": True,
             "max_context": 1_050_000,
             "max_output": 128_000,
-        },
-        "metadata": {
-            # The advertised GPT-5.4 window is large, but the interactive Codex
-            # experience compacts much earlier. Use the smaller effective window
-            # for UI/compaction decisions while preserving the raw capability.
-            "effective_context_window": 258_000,
         },
     },
 ]

--- a/backend/app/session/compaction.py
+++ b/backend/app/session/compaction.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 PROTECTED_TOKEN_BUDGET = 40_000  # Protect this many tokens of tool output
 SKIP_RECENT_TURNS = 2  # Don't compact the last N assistant messages
 PROTECTED_TOOLS = frozenset({"skill"})  # Never prune these tool outputs
+AUTO_COMPACT_CONTEXT_RATIO = 0.85  # Proactively compact before the hard context edge
 
 
 @dataclass
@@ -337,13 +338,16 @@ def should_compact(
     *,
     model_max_output: int | None = None,
     reserved: int | None = None,
+    threshold_ratio: float = AUTO_COMPACT_CONTEXT_RATIO,
 ) -> bool:
     """Check if context usage warrants compaction.
 
     Mirrors OpenCode ``SessionCompaction.isOverflow()`` budget shape:
       - reserved defaults to ``min(20_000, model_max_output)``
       - usable = model_max_context - output_budget - reserved
-      - auto compact starts at 90% of usable context
+
+    Also applies a proactive threshold so compaction starts around 85% of the
+    provider-reported context window instead of waiting for the hard edge.
     """
     total_tokens = usage.get("total", 0)
     if not total_tokens:
@@ -358,5 +362,5 @@ def should_compact(
         model_max_output=model_max_output,
         reserved=reserved,
     )
-    threshold = int(usable * 0.9)
+    threshold = min(usable, int(model_max_context * threshold_ratio))
     return total_tokens >= threshold and threshold > 0

--- a/backend/tests/test_session/test_compaction.py
+++ b/backend/tests/test_session/test_compaction.py
@@ -12,15 +12,38 @@ class TestShouldCompact:
         usage = {"input": 120_000, "output": 5_000}
         assert should_compact(usage, model_max_context=128_000, reserved=20_000)
 
-    def test_just_below_ninety_percent_threshold(self):
-        usage = {"input": 89_826, "output": 0}
+    def test_below_output_safe_threshold(self):
+        usage = {"input": 99_807, "output": 0}
         # usable = 128000 - 8192(effective_output) - 20000(reserved) = 99808
-        # threshold = int(99808 * 0.9) = 89827
         assert not should_compact(usage, model_max_context=128_000, reserved=20_000)
 
-    def test_at_ninety_percent_threshold(self):
-        usage = {"input": 89_827, "output": 0}
+    def test_over_output_safe_threshold(self):
+        usage = {"input": 99_809, "output": 0}
         assert should_compact(usage, model_max_context=128_000, reserved=20_000)
+
+    def test_proactive_threshold_uses_eighty_five_percent_context(self):
+        usage = {"input": 108_800, "output": 0}
+        assert should_compact(
+            usage,
+            model_max_context=128_000,
+            model_max_output=512,
+        )
+
+    def test_below_proactive_threshold_when_output_reserve_allows_more(self):
+        usage = {"input": 108_799, "output": 0}
+        assert not should_compact(
+            usage,
+            model_max_context=128_000,
+            model_max_output=512,
+        )
+
+    def test_large_context_model_compacts_at_eighty_five_percent(self):
+        usage = {"input": 892_500, "output": 0}
+        assert should_compact(
+            usage,
+            model_max_context=1_050_000,
+            model_max_output=128_000,
+        )
 
     def test_empty_usage(self):
         assert not should_compact({}, model_max_context=128_000)


### PR DESCRIPTION
## Summary

- remove the hardcoded 258k effective-context override for ChatGPT subscription GPT-5.5/GPT-5.4 models
- keep provider-reported context windows available to the UI and budgeting code
- start automatic compaction at the stricter of output/reserve-safe budget or 85% of the reported context window
- add compaction threshold regression coverage and an Unreleased changelog note

## Why

Discussion #83 reported that large-context models were being capped far below their advertised context window. The root cause was the explicit ChatGPT subscription effective-window metadata plus an early compaction threshold that did not match the desired 85% operating point.

## Validation

- `/Users/wangzhangwu/openyak/backend/venv/bin/python -m pytest tests/test_session/test_compaction.py tests/test_session/test_utils.py tests/test_provider/test_provider_registry.py`
- GUI smoke test with a temporary local OpenAI-compatible provider and seeded 850k-token session: the context tooltip showed `850k / 1M tokens used` and exposed `Click to compact now`.
