### PR TITLE
refactor(settings): split ProvidersTab into per-mode panels

### DIFF
--- a/frontend/src/components/settings/providers-tab.tsx
+++ b/frontend/src/components/settings/providers-tab.tsx
@@ -1,83 +1,132 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
-  Eye,
-  EyeOff,
-  X,
-  Check,
-  Loader2,
-  AlertCircle,
-  LogOut,
   CreditCard,
-  RotateCw,
   Cpu,
-  Zap,
+  Eye,
   Plug,
+  Zap,
 } from "lucide-react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useSettingsStore } from "@/stores/settings-store";
-import { api, ApiError } from "@/lib/api";
-import { errorToMessage } from "@/lib/errors";
-import { API, IS_DESKTOP, queryKeys } from "@/lib/constants";
-import { desktopAPI } from "@/lib/tauri-api";
+import { api } from "@/lib/api";
+import { API, queryKeys } from "@/lib/constants";
 import { useModels } from "@/hooks/use-models";
 import type {
   ApiKeyStatus,
-  ProviderInfo,
   LocalProviderStatus,
+  ProviderInfo,
 } from "@/types/usage";
 import type { ModelInfo } from "@/types/model";
 import { OllamaPanel } from "@/components/settings/ollama-panel";
 import { RapidMLXPanel } from "@/components/settings/rapid-mlx-panel";
+import { ByokPanel } from "@/components/settings/providers/byok-panel";
+import { ChatGPTSubPanel } from "@/components/settings/providers/chatgpt-sub-panel";
+import { CustomEndpointPanel } from "@/components/settings/providers/custom-endpoint-panel";
 
-/** Backwards-compatible alias for callers that still expect ApiError-only narrowing. */
-function extractApiDetail(err: unknown, fallback: string): string {
-  if (!(err instanceof ApiError)) return fallback;
-  return errorToMessage(err, fallback);
-}
+type ProviderMode = "byok" | "chatgpt" | "ollama" | "rapid-mlx" | "custom";
 
 interface OpenAISubscriptionStatus {
   is_connected: boolean;
-  email: string;
-  needs_reauth?: boolean;
+}
+interface OllamaRuntimeStatus {
+  binary_installed: boolean;
+  running: boolean;
+}
+interface RapidMLXRuntimeStatus {
+  running: boolean;
+}
+
+function pickModelForMode(
+  mode: ProviderMode,
+  models: ModelInfo[] | undefined,
+): ModelInfo | null {
+  if (!models || models.length === 0) return null;
+  if (mode === "byok") {
+    return (
+      models.find(
+        (m) =>
+          !["openai-subscription", "ollama", "rapid-mlx", "local"].includes(
+            m.provider_id,
+          ) && !m.provider_id?.startsWith("custom_"),
+      ) ?? null
+    );
+  }
+  if (mode === "chatgpt") {
+    return (
+      models.find((m) => m.provider_id === "openai-subscription") ?? null
+    );
+  }
+  if (mode === "ollama") {
+    return models.find((m) => m.provider_id === "ollama") ?? null;
+  }
+  if (mode === "rapid-mlx") {
+    return models.find((m) => m.provider_id === "rapid-mlx") ?? null;
+  }
+  if (mode === "custom") {
+    return (
+      models.find(
+        (m) =>
+          m.provider_id === "local" || m.provider_id?.startsWith("custom_"),
+      ) ?? null
+    );
+  }
+  return null;
 }
 
 export function ProvidersTab() {
   const { t } = useTranslation("settings");
   const { activeProvider, setActiveProvider } = useSettingsStore();
 
-  type ProviderMode = "byok" | "chatgpt" | "ollama" | "rapid-mlx" | "custom";
   const [viewingProvider, setViewingProvider] = useState<ProviderMode>(
     () => (activeProvider as ProviderMode) ?? "byok",
   );
-
   const [mounted, setMounted] = useState(false);
-  const qc = useQueryClient();
+
   const { data: allModels } = useModels();
 
   const { data: keyStatus } = useQuery({
     queryKey: queryKeys.apiKeyStatus,
     queryFn: () => api.get<ApiKeyStatus>(API.CONFIG.API_KEY),
   });
-
-  // Multi-provider BYOK status
   const { data: providers } = useQuery({
     queryKey: queryKeys.providers,
     queryFn: () => api.get<ProviderInfo[]>(API.CONFIG.PROVIDERS),
   });
-
   const { data: localStatus } = useQuery({
     queryKey: queryKeys.localProvider,
     queryFn: () => api.get<LocalProviderStatus>(API.CONFIG.LOCAL_PROVIDER),
+  });
+  const { data: openaiSubStatus } = useQuery({
+    queryKey: queryKeys.openaiSubscription,
+    queryFn: () =>
+      api.get<OpenAISubscriptionStatus>(API.CONFIG.OPENAI_SUBSCRIPTION),
+  });
+  const { data: ollamaRuntimeStatus } = useQuery({
+    queryKey: ["ollamaRuntime"],
+    queryFn: () => api.get<OllamaRuntimeStatus>(API.OLLAMA.STATUS),
+  });
+  const { data: rapidMlxRuntimeStatus } = useQuery({
+    queryKey: ["rapidMlxRuntime"],
+    queryFn: () => api.get<RapidMLXRuntimeStatus>(API.RAPID_MLX.STATUS),
+    retry: false,
   });
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  const activateProviderMode = (mode: ProviderMode) => {
+    setActiveProvider(mode);
+    const picked = pickModelForMode(mode, allModels);
+    if (picked) {
+      useSettingsStore
+        .getState()
+        .setSelectedModel(picked.id, picked.provider_id);
+    }
+  };
 
   const fallbackToOtherProviders = () => {
     if (openaiSubStatus?.is_connected) {
@@ -101,351 +150,6 @@ export function ProvidersTab() {
     }
   };
 
-  const pickModelForMode = (
-    mode: ProviderMode,
-    models: ModelInfo[] | undefined,
-  ) => {
-    if (!models || models.length === 0) return null;
-    if (mode === "byok") {
-      return (
-        models.find(
-          (m) =>
-            !["openai-subscription", "ollama", "rapid-mlx", "local"].includes(
-              m.provider_id,
-            ) && !m.provider_id?.startsWith("custom_"),
-        ) ?? null
-      );
-    }
-    if (mode === "chatgpt") {
-      return (
-        models.find((m) => m.provider_id === "openai-subscription") ?? null
-      );
-    }
-    if (mode === "ollama") {
-      return models.find((m) => m.provider_id === "ollama") ?? null;
-    }
-    if (mode === "rapid-mlx") {
-      return models.find((m) => m.provider_id === "rapid-mlx") ?? null;
-    }
-    if (mode === "custom") {
-      return (
-        models.find(
-          (m) =>
-            m.provider_id === "local" || m.provider_id?.startsWith("custom_"),
-        ) ?? null
-      );
-    }
-    return null;
-  };
-
-  const activateProviderMode = (mode: ProviderMode) => {
-    setActiveProvider(mode);
-    const picked = pickModelForMode(mode, allModels);
-    if (picked) {
-      useSettingsStore
-        .getState()
-        .setSelectedModel(picked.id, picked.provider_id);
-    }
-  };
-
-  const { data: openaiSubStatus, refetch: refetchOpenaiSub } = useQuery({
-    queryKey: queryKeys.openaiSubscription,
-    queryFn: () =>
-      api.get<OpenAISubscriptionStatus>(API.CONFIG.OPENAI_SUBSCRIPTION),
-  });
-
-  // Per-provider key input state and mutations
-  const [providerKeyInputs, setProviderKeyInputs] = useState<
-    Record<string, string>
-  >({});
-  const [providerBaseUrlInputs, setProviderBaseUrlInputs] = useState<
-    Record<string, string>
-  >({});
-  const [showProviderKey, setShowProviderKey] = useState<
-    Record<string, boolean>
-  >({});
-  const [providerMutatingId, setProviderMutatingId] = useState<string | null>(
-    null,
-  );
-  const [providerError, setProviderError] = useState<Record<string, string>>(
-    {},
-  );
-  const [customEndpointName, setCustomEndpointName] = useState<string>("");
-
-  const updateProviderKey = useMutation({
-    mutationFn: async ({
-      id,
-      apiKey,
-      baseUrl,
-    }: {
-      id: string;
-      apiKey: string;
-      baseUrl?: string;
-    }) => {
-      setProviderMutatingId(id);
-      return api.post<ProviderInfo>(API.CONFIG.PROVIDER_KEY(id), {
-        api_key: apiKey,
-        base_url: baseUrl,
-      });
-    },
-    onSuccess: (_data, { id }) => {
-      setProviderKeyInputs((prev) => ({ ...prev, [id]: "" }));
-      setProviderError((prev) => {
-        const next = { ...prev };
-        delete next[id];
-        return next;
-      });
-      setProviderMutatingId(null);
-      activateProviderMode("byok");
-      qc.invalidateQueries({ queryKey: queryKeys.providers });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-    onError: (err, { id }) => {
-      setProviderMutatingId(null);
-      const detail = errorToMessage(err, t("failedSaveKey"));
-      setProviderError((prev) => ({ ...prev, [id]: detail }));
-    },
-  });
-
-  const deleteProviderKey = useMutation({
-    mutationFn: async (id: string) => {
-      setProviderMutatingId(id);
-      return api.delete<ProviderInfo>(API.CONFIG.PROVIDER_KEY(id));
-    },
-    onSuccess: () => {
-      setProviderMutatingId(null);
-      qc.invalidateQueries({ queryKey: queryKeys.providers });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-    onError: () => {
-      setProviderMutatingId(null);
-    },
-  });
-
-  const toggleProvider = useMutation({
-    mutationFn: (id: string) =>
-      api.post<ProviderInfo>(API.CONFIG.PROVIDER_TOGGLE(id)),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.providers });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-  });
-
-  const createCustomEndpoint = useMutation({
-    mutationFn: async ({
-      name,
-      apiKey,
-      baseUrl,
-    }: {
-      name: string;
-      apiKey?: string;
-      baseUrl: string;
-    }) => {
-      setProviderMutatingId("custom_new");
-      return api.post<ProviderInfo>(API.CONFIG.CUSTOM_ENDPOINT, {
-        name,
-        api_key: apiKey || "",
-        base_url: baseUrl,
-      });
-    },
-    onSuccess: () => {
-      setProviderKeyInputs((prev) => ({ ...prev, ["custom_new"]: "" }));
-      setProviderBaseUrlInputs((prev) => ({ ...prev, ["custom_new"]: "" }));
-      setCustomEndpointName("");
-      setProviderError((prev) => {
-        const next = { ...prev };
-        delete next["custom_new"];
-        return next;
-      });
-      setProviderMutatingId(null);
-      qc.invalidateQueries({ queryKey: queryKeys.providers });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-    onError: (err) => {
-      setProviderMutatingId(null);
-      setProviderError((prev) => ({
-        ...prev,
-        ["custom_new"]: extractApiDetail(err, "Failed to save endpoint"),
-      }));
-    },
-  });
-
-  const deleteCustomEndpoint = useMutation({
-    mutationFn: async (id: string) => {
-      setProviderMutatingId(id);
-      return api.delete<ProviderInfo>(API.CONFIG.CUSTOM_ENDPOINT_ITEM(id));
-    },
-    onSuccess: () => {
-      setProviderMutatingId(null);
-      qc.invalidateQueries({ queryKey: queryKeys.providers });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-    onError: () => {
-      setProviderMutatingId(null);
-    },
-  });
-
-  const updateCustomEndpoint = useMutation({
-    mutationFn: async ({
-      id,
-      name,
-      apiKey,
-      baseUrl,
-      enabled,
-    }: {
-      id: string;
-      name?: string;
-      apiKey?: string;
-      baseUrl?: string;
-      enabled?: boolean;
-    }) => {
-      setProviderMutatingId(id);
-      const body: Record<string, unknown> = {};
-      if (name !== undefined) body.name = name;
-      if (apiKey !== undefined) body.api_key = apiKey;
-      if (baseUrl !== undefined) body.base_url = baseUrl;
-      if (enabled !== undefined) body.enabled = enabled;
-      return api.patch<ProviderInfo>(API.CONFIG.CUSTOM_ENDPOINT_ITEM(id), body);
-    },
-    onSuccess: () => {
-      setProviderMutatingId(null);
-      qc.invalidateQueries({ queryKey: queryKeys.providers });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-    onError: (err, { id }) => {
-      setProviderMutatingId(null);
-      setProviderError((prev) => ({
-        ...prev,
-        [id]: extractApiDetail(err, "Failed to update endpoint"),
-      }));
-    },
-  });
-
-  const deleteLocalProvider = useMutation({
-    mutationFn: () =>
-      api.delete<LocalProviderStatus>(API.CONFIG.LOCAL_PROVIDER),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: queryKeys.localProvider });
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-      setProviderError((prev) => {
-        const next = { ...prev };
-        delete next["local_legacy"];
-        return next;
-      });
-      if (activeProvider === "custom") {
-        fallbackToOtherProviders();
-      }
-    },
-    onError: (err) => {
-      const detail = errorToMessage(err, t("failedSaveKey"));
-      setProviderError((prev) => ({ ...prev, ["local_legacy"]: detail }));
-    },
-  });
-
-  const openaiDisconnectMutation = useMutation({
-    mutationFn: () => api.delete(API.CONFIG.OPENAI_SUBSCRIPTION),
-    onSuccess: () => {
-      refetchOpenaiSub();
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-      if (activeProvider === "chatgpt") {
-        if (keyStatus?.is_configured) setActiveProvider("byok");
-        else setActiveProvider(null);
-      }
-    },
-  });
-
-  const [openaiPolling, setOpenaiPolling] = useState(false);
-  const [callbackUrlInput, setCallbackUrlInput] = useState("");
-  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
-    null,
-  );
-  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const stopOpenaiPolling = useCallback(() => {
-    if (pollingIntervalRef.current) {
-      clearInterval(pollingIntervalRef.current);
-      pollingIntervalRef.current = null;
-    }
-    if (pollingTimeoutRef.current) {
-      clearTimeout(pollingTimeoutRef.current);
-      pollingTimeoutRef.current = null;
-    }
-    setOpenaiPolling(false);
-  }, []);
-
-  const startOpenaiPolling = useCallback(() => {
-    stopOpenaiPolling();
-    setOpenaiPolling(true);
-    let consecutiveFailures = 0;
-    const interval = setInterval(async () => {
-      try {
-        const status = await api.get<OpenAISubscriptionStatus>(
-          API.CONFIG.OPENAI_SUBSCRIPTION,
-        );
-        consecutiveFailures = 0;
-        if (status.is_connected) {
-          stopOpenaiPolling();
-          refetchOpenaiSub();
-          setActiveProvider("chatgpt");
-          qc.invalidateQueries({ queryKey: queryKeys.models });
-        }
-      } catch (err) {
-        consecutiveFailures += 1;
-        console.warn("OpenAI subscription auth polling failed", err);
-        if (consecutiveFailures >= 3) {
-          stopOpenaiPolling();
-        }
-      }
-    }, 2000);
-    pollingIntervalRef.current = interval;
-    pollingTimeoutRef.current = setTimeout(stopOpenaiPolling, 300_000);
-  }, [qc, refetchOpenaiSub, setActiveProvider, stopOpenaiPolling]);
-
-  useEffect(() => stopOpenaiPolling, [stopOpenaiPolling]);
-
-  const openaiLoginMutation = useMutation({
-    mutationFn: async () => {
-      const resp = await api.post<{ auth_url: string }>(
-        API.CONFIG.OPENAI_SUBSCRIPTION_LOGIN,
-        {},
-      );
-      if (IS_DESKTOP) await desktopAPI.openExternal(resp.auth_url);
-      else window.open(resp.auth_url, "_blank", "noopener,noreferrer");
-    },
-    onSuccess: startOpenaiPolling,
-    onError: stopOpenaiPolling,
-  });
-
-  const manualCallbackMutation = useMutation({
-    mutationFn: () =>
-      api.post<{ success: boolean; email: string }>(
-        API.CONFIG.OPENAI_SUBSCRIPTION_MANUAL_CALLBACK,
-        { callback_url: callbackUrlInput },
-      ),
-    onSuccess: () => {
-      setCallbackUrlInput("");
-      stopOpenaiPolling();
-      setActiveProvider("chatgpt");
-      qc.invalidateQueries({ queryKey: queryKeys.models });
-    },
-  });
-
-  interface OllamaRuntimeStatus {
-    binary_installed: boolean;
-    running: boolean;
-  }
-  interface RapidMLXRuntimeStatus {
-    running: boolean;
-  }
-  const { data: ollamaRuntimeStatus } = useQuery({
-    queryKey: ["ollamaRuntime"],
-    queryFn: () => api.get<OllamaRuntimeStatus>(API.OLLAMA.STATUS),
-  });
-  const { data: rapidMlxRuntimeStatus } = useQuery({
-    queryKey: ["rapidMlxRuntime"],
-    queryFn: () => api.get<RapidMLXRuntimeStatus>(API.RAPID_MLX.STATUS),
-    retry: false,
-  });
   const ollamaConnected = !!ollamaRuntimeStatus?.running;
   const rapidMlxConnected = !!rapidMlxRuntimeStatus?.running;
   const customConnected =
@@ -453,6 +157,43 @@ export function ProvidersTab() {
     (providers ?? []).some(
       (p) => p.id.startsWith("custom_") && p.is_configured,
     );
+
+  const modes: Array<{
+    mode: ProviderMode;
+    label: string;
+    icon: typeof Eye;
+    connected: boolean;
+  }> = [
+    {
+      mode: "byok",
+      label: t("ownApiKey"),
+      icon: Eye,
+      connected:
+        !!keyStatus?.is_configured ||
+        (providers ?? []).some(
+          (p) => p.is_configured && !p.id.startsWith("custom_"),
+        ),
+    },
+    {
+      mode: "chatgpt",
+      label: t("chatgptSubscription"),
+      icon: CreditCard,
+      connected: !!openaiSubStatus?.is_connected,
+    },
+    { mode: "ollama", label: "Ollama", icon: Cpu, connected: ollamaConnected },
+    {
+      mode: "rapid-mlx",
+      label: "Rapid-MLX",
+      icon: Zap,
+      connected: rapidMlxConnected,
+    },
+    {
+      mode: "custom",
+      label: t("customEndpoint"),
+      icon: Plug,
+      connected: customConnected,
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -462,42 +203,7 @@ export function ProvidersTab() {
 
       {/* Provider cards */}
       <div className="grid grid-cols-2 lg:grid-cols-5 gap-2">
-        {[
-          {
-            mode: "byok" as ProviderMode,
-            label: t("ownApiKey"),
-            icon: Eye,
-            connected:
-              !!keyStatus?.is_configured ||
-              (providers ?? []).some(
-                (p) => p.is_configured && !p.id.startsWith("custom_"),
-              ),
-          },
-          {
-            mode: "chatgpt" as ProviderMode,
-            label: t("chatgptSubscription"),
-            icon: CreditCard,
-            connected: !!openaiSubStatus?.is_connected,
-          },
-          {
-            mode: "ollama" as ProviderMode,
-            label: "Ollama",
-            icon: Cpu,
-            connected: ollamaConnected,
-          },
-          {
-            mode: "rapid-mlx" as ProviderMode,
-            label: "Rapid-MLX",
-            icon: Zap,
-            connected: rapidMlxConnected,
-          },
-          {
-            mode: "custom" as ProviderMode,
-            label: t("customEndpoint"),
-            icon: Plug,
-            connected: customConnected,
-          },
-        ].map(({ mode, label, icon: Icon, connected }) => (
+        {modes.map(({ mode, label, icon: Icon, connected }) => (
           <button
             key={mode}
             onClick={() => {
@@ -526,496 +232,26 @@ export function ProvidersTab() {
         ))}
       </div>
 
-      {/* Own API Key config */}
       {viewingProvider === "byok" && (
-        <div className="space-y-4">
-          <p className="text-xs text-[var(--text-secondary)]">
-            {t("byokDesc")}
-          </p>
-
-          {/* All BYOK providers (OpenRouter, OpenAI, Anthropic, Gemini, etc.) */}
-          {(providers ?? [])
-            .filter((p) => !p.id.startsWith("custom_"))
-            .map((p) => (
-              <div
-                key={p.id}
-                className={`rounded-lg border p-3 space-y-2 transition-opacity ${
-                  p.is_configured && !p.enabled
-                    ? "border-[var(--border-default)] opacity-50"
-                    : "border-[var(--border-default)]"
-                }`}
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-medium text-[var(--text-primary)]">
-                    {p.name}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    {p.is_configured && p.enabled && (
-                      <span className="text-ui-3xs text-[var(--text-tertiary)]">
-                        {p.model_count} {t("providerModels")}
-                      </span>
-                    )}
-                    {p.is_configured && (
-                      <button
-                        type="button"
-                        onClick={() => toggleProvider.mutate(p.id)}
-                        disabled={toggleProvider.isPending}
-                        className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
-                          p.enabled
-                            ? "bg-[var(--color-success)]"
-                            : "bg-[var(--surface-tertiary)]"
-                        }`}
-                        title={
-                          p.enabled ? t("disableProvider") : t("enableProvider")
-                        }
-                      >
-                        <span
-                          className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${
-                            p.enabled ? "translate-x-3" : "translate-x-0"
-                          }`}
-                        />
-                      </button>
-                    )}
-                  </div>
-                </div>
-                {p.is_configured && (
-                  <div className="flex items-center gap-2 text-xs">
-                    <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
-                    <span className="text-[var(--text-secondary)] font-mono">
-                      {p.masked_key}
-                    </span>
-                    <button
-                      onClick={() => deleteProviderKey.mutate(p.id)}
-                      disabled={providerMutatingId === p.id}
-                      className="ml-1 text-[var(--text-tertiary)] hover:text-[var(--color-destructive)] transition-colors"
-                      title={t("removeApiKey")}
-                    >
-                      {providerMutatingId === p.id ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <X className="h-3.5 w-3.5" />
-                      )}
-                    </button>
-                  </div>
-                )}
-                <div className="flex items-start gap-2">
-                  <div className="flex-1 space-y-2">
-                    <div className="relative">
-                      <Input
-                        type={showProviderKey[p.id] ? "text" : "password"}
-                        value={providerKeyInputs[p.id] ?? ""}
-                        onChange={(e) =>
-                          setProviderKeyInputs((prev) => ({
-                            ...prev,
-                            [p.id]: e.target.value,
-                          }))
-                        }
-                        placeholder={t(`providerKeyPlaceholder_${p.id}`, {
-                          defaultValue: `${p.name} API key`,
-                        })}
-                        className="pr-8 font-mono text-xs"
-                        autoComplete="one-time-code"
-                        data-form-type="other"
-                      />
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setShowProviderKey((prev) => ({
-                            ...prev,
-                            [p.id]: !prev[p.id],
-                          }))
-                        }
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
-                      >
-                        {showProviderKey[p.id] ? (
-                          <EyeOff className="h-3.5 w-3.5" />
-                        ) : (
-                          <Eye className="h-3.5 w-3.5" />
-                        )}
-                      </button>
-                    </div>
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() =>
-                      updateProviderKey.mutate({
-                        id: p.id,
-                        apiKey: providerKeyInputs[p.id] ?? "",
-                      })
-                    }
-                    disabled={
-                      !(providerKeyInputs[p.id] ?? "").trim() ||
-                      providerMutatingId === p.id
-                    }
-                  >
-                    {providerMutatingId === p.id ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      t("save")
-                    )}
-                  </Button>
-                </div>
-                {providerError[p.id] && (
-                  <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
-                    <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                    <span>{providerError[p.id]}</span>
-                  </div>
-                )}
-              </div>
-            ))}
-        </div>
+        <ByokPanel
+          providers={providers}
+          onSaved={() => activateProviderMode("byok")}
+        />
       )}
-
-      {/* ChatGPT Subscription config */}
       {viewingProvider === "chatgpt" && (
-        <div>
-          <p className="text-xs text-[var(--text-secondary)] mb-3">
-            {t("chatgptSubscriptionDesc")}
-          </p>
-          {openaiSubStatus?.is_connected ? (
-            <div className="space-y-3">
-              <div
-                className={`rounded-lg border p-3 ${openaiSubStatus.needs_reauth ? "border-[var(--color-warning)]" : "border-[var(--border-default)]"}`}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    {openaiSubStatus.needs_reauth ? (
-                      <AlertCircle className="h-3.5 w-3.5 text-[var(--color-warning)]" />
-                    ) : (
-                      <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
-                    )}
-                    <span className="text-xs text-[var(--text-secondary)]">
-                      {openaiSubStatus.email || t("chatgptConnected")}
-                    </span>
-                  </div>
-                  <span
-                    className={`text-xs font-medium ${openaiSubStatus.needs_reauth ? "text-[var(--color-warning)]" : "text-[var(--color-success)]"}`}
-                  >
-                    {openaiSubStatus.needs_reauth
-                      ? t("chatgptNeedsReauth")
-                      : t("chatgptActive")}
-                  </span>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                {openaiSubStatus.needs_reauth && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => openaiLoginMutation.mutate()}
-                    disabled={openaiLoginMutation.isPending || openaiPolling}
-                  >
-                    {openaiLoginMutation.isPending || openaiPolling ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-                    ) : (
-                      <RotateCw className="h-3.5 w-3.5 mr-1.5" />
-                    )}
-                    {t("chatgptSignIn")}
-                  </Button>
-                )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => openaiDisconnectMutation.mutate()}
-                  disabled={openaiDisconnectMutation.isPending}
-                >
-                  {openaiDisconnectMutation.isPending ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-                  ) : (
-                    <LogOut className="h-3.5 w-3.5 mr-1.5" />
-                  )}
-                  {t("disconnect")}
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => openaiLoginMutation.mutate()}
-                disabled={openaiLoginMutation.isPending || openaiPolling}
-              >
-                {openaiLoginMutation.isPending || openaiPolling ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
-                ) : null}
-                {openaiPolling ? t("chatgptWaiting") : t("chatgptSignIn")}
-              </Button>
-              {openaiLoginMutation.isError && (
-                <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
-                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                  <span>{t("chatgptLoginFailed")}</span>
-                </div>
-              )}
-              {openaiPolling && (
-                <div className="space-y-2 pt-2">
-                  <p className="text-xs text-[var(--text-secondary)]">
-                    {t("chatgptPasteInstruction")}
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <Input
-                      type="text"
-                      value={callbackUrlInput}
-                      onChange={(e) => setCallbackUrlInput(e.target.value)}
-                      placeholder={t("chatgptPastePlaceholder")}
-                      className="font-mono text-xs"
-                    />
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => manualCallbackMutation.mutate()}
-                      disabled={
-                        !callbackUrlInput.trim() ||
-                        manualCallbackMutation.isPending
-                      }
-                    >
-                      {manualCallbackMutation.isPending ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        t("chatgptSubmitCallback")
-                      )}
-                    </Button>
-                  </div>
-                  {manualCallbackMutation.isError && (
-                    <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
-                      <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                      <span>{t("chatgptManualCallbackFailed")}</span>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
+        <ChatGPTSubPanel keyStatus={keyStatus} />
       )}
-
-      {/* Ollama (Local LLM) config */}
       {viewingProvider === "ollama" && <OllamaPanel />}
-
-      {/* Rapid-MLX (Apple Silicon local LLM) config */}
       {viewingProvider === "rapid-mlx" && <RapidMLXPanel />}
-
-      {/* Custom OpenAI-compatible endpoints */}
-      {viewingProvider === "custom" &&
-        (() => {
-          const customProviders =
-            providers?.filter((p) => p.id.startsWith("custom_")) || [];
-          const hasLegacyLocal = !!localStatus?.is_configured;
-          return (
-            <div className="space-y-6">
-              <p className="text-xs text-[var(--text-secondary)]">
-                {t("customEndpointDesc")}
-              </p>
-
-              {(hasLegacyLocal || customProviders.length > 0) && (
-                <div className="space-y-4">
-                  <h4 className="text-xs font-semibold text-[var(--text-secondary)]">
-                    {t("savedEndpoints")}
-                  </h4>
-                  {hasLegacyLocal && (
-                    <div
-                      className={`p-3 border border-[var(--border-primary)] rounded-lg bg-[var(--surface-secondary)] ${localStatus?.status === "error" ? "border-[var(--color-destructive)]/40" : ""}`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex min-w-0 items-center gap-2 text-xs">
-                          <span className="font-semibold">
-                            {t("localProvider")}
-                          </span>
-                          <span className="text-[var(--text-secondary)] font-mono ml-2 text-ui-3xs bg-[var(--surface-primary)] px-2 py-0.5 rounded truncate">
-                            {localStatus?.base_url}
-                          </span>
-                          {localStatus?.status === "error" && (
-                            <span className="text-[var(--color-destructive)] text-ui-3xs">
-                              {t("localProviderConnectError")}
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-[var(--color-destructive)] hover:text-[var(--color-destructive)] hover:bg-[var(--color-destructive)]/10"
-                            onClick={() => deleteLocalProvider.mutate()}
-                            disabled={deleteLocalProvider.isPending}
-                          >
-                            {deleteLocalProvider.isPending ? (
-                              <Loader2 className="h-3 w-3 animate-spin" />
-                            ) : (
-                              <LogOut className="h-3 w-3" />
-                            )}
-                          </Button>
-                        </div>
-                      </div>
-                      {providerError["local_legacy"] && (
-                        <div className="mt-2 flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
-                          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                          <span>{providerError["local_legacy"]}</span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  {customProviders.map((p) => (
-                    <div
-                      key={p.id}
-                      className={`p-3 border border-[var(--border-primary)] rounded-lg bg-[var(--surface-secondary)] ${!p.enabled ? "opacity-50" : ""}`}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2 text-xs">
-                          <span className="font-semibold">
-                            {p.name || t("customEndpoint")}
-                          </span>
-                          <span className="text-[var(--text-secondary)] font-mono ml-2 text-ui-3xs bg-[var(--surface-primary)] px-2 py-0.5 rounded">
-                            {p.base_url}
-                          </span>
-                          {p.masked_key && (
-                            <span className="text-[var(--text-tertiary)] font-mono ml-2 text-ui-3xs">
-                              Key: {p.masked_key}
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-ui-3xs text-[var(--text-tertiary)]">
-                            {p.model_count} models
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() =>
-                              updateCustomEndpoint.mutate({
-                                id: p.id,
-                                enabled: !p.enabled,
-                              })
-                            }
-                            disabled={updateCustomEndpoint.isPending}
-                            className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
-                              p.enabled
-                                ? "bg-[var(--color-success)]"
-                                : "bg-[var(--surface-tertiary)]"
-                            }`}
-                            title={
-                              p.enabled
-                                ? t("disableProvider")
-                                : t("enableProvider")
-                            }
-                          >
-                            <span
-                              className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${
-                                p.enabled ? "translate-x-3" : "translate-x-0"
-                              }`}
-                            />
-                          </button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-[var(--color-destructive)] hover:text-[var(--color-destructive)] hover:bg-[var(--color-destructive)]/10"
-                            onClick={() => deleteCustomEndpoint.mutate(p.id)}
-                            disabled={providerMutatingId === p.id}
-                          >
-                            {providerMutatingId === p.id ? (
-                              <Loader2 className="h-3 w-3 animate-spin" />
-                            ) : (
-                              <LogOut className="h-3 w-3" />
-                            )}
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              <div className="space-y-4 pt-4 border-t border-[var(--border-primary)]">
-                <h4 className="text-xs font-semibold text-[var(--text-secondary)]">
-                  {t("addNewCustomEndpoint")}
-                </h4>
-                <div className="space-y-3 p-3 bg-[var(--surface-secondary)] rounded-lg">
-                  <Input
-                    type="text"
-                    value={customEndpointName}
-                    onChange={(e) => setCustomEndpointName(e.target.value)}
-                    placeholder={t("endpointNamePlaceholder")}
-                    className="text-xs bg-[var(--surface-primary)]"
-                  />
-                  <Input
-                    type="text"
-                    value={providerBaseUrlInputs["custom_new"] ?? ""}
-                    onChange={(e) =>
-                      setProviderBaseUrlInputs((prev) => ({
-                        ...prev,
-                        ["custom_new"]: e.target.value,
-                      }))
-                    }
-                    placeholder={t("providerUrlPlaceholder_custom", {
-                      defaultValue:
-                        "Base URL (e.g. https://api.myendpoint.com/v1)",
-                    })}
-                    className="font-mono text-xs bg-[var(--surface-primary)]"
-                  />
-                  <div className="relative">
-                    <Input
-                      type={showProviderKey["custom_new"] ? "text" : "password"}
-                      value={providerKeyInputs["custom_new"] ?? ""}
-                      onChange={(e) =>
-                        setProviderKeyInputs((prev) => ({
-                          ...prev,
-                          ["custom_new"]: e.target.value,
-                        }))
-                      }
-                      placeholder={t("apiKeyPlaceholderOptional")}
-                      className="pr-8 font-mono text-xs bg-[var(--surface-primary)]"
-                      autoComplete="one-time-code"
-                    />
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setShowProviderKey((prev) => ({
-                          ...prev,
-                          ["custom_new"]: !prev["custom_new"],
-                        }))
-                      }
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
-                    >
-                      {showProviderKey["custom_new"] ? (
-                        <EyeOff className="h-3.5 w-3.5" />
-                      ) : (
-                        <Eye className="h-3.5 w-3.5" />
-                      )}
-                    </button>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    {providerError["custom_new"] && (
-                      <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
-                        <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                        <span>{providerError["custom_new"]}</span>
-                      </div>
-                    )}
-                    <Button
-                      variant="default"
-                      size="sm"
-                      className="ml-auto"
-                      onClick={() =>
-                        createCustomEndpoint.mutate({
-                          name: customEndpointName || "Custom Endpoint",
-                          apiKey: providerKeyInputs["custom_new"] ?? "",
-                          baseUrl: providerBaseUrlInputs["custom_new"] ?? "",
-                        })
-                      }
-                      disabled={
-                        !(providerBaseUrlInputs["custom_new"] ?? "").trim() ||
-                        providerMutatingId === "custom_new"
-                      }
-                    >
-                      {providerMutatingId === "custom_new" ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
-                      ) : null}
-                      {t("addEndpoint")}
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })()}
+      {viewingProvider === "custom" && (
+        <CustomEndpointPanel
+          providers={providers}
+          localStatus={localStatus}
+          onLocalDeleted={() => {
+            if (activeProvider === "custom") fallbackToOtherProviders();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/settings/providers/byok-panel.tsx
+++ b/frontend/src/components/settings/providers/byok-panel.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, Check, Eye, EyeOff, Loader2, X } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api } from "@/lib/api";
+import { errorToMessage } from "@/lib/errors";
+import { API, queryKeys } from "@/lib/constants";
+import type { ProviderInfo } from "@/types/usage";
+
+interface ByokPanelProps {
+  providers: ProviderInfo[] | undefined;
+  onSaved: () => void;
+}
+
+export function ByokPanel({ providers, onSaved }: ByokPanelProps) {
+  const { t } = useTranslation("settings");
+  const qc = useQueryClient();
+
+  const [keyInputs, setKeyInputs] = useState<Record<string, string>>({});
+  const [showKey, setShowKey] = useState<Record<string, boolean>>({});
+  const [mutatingId, setMutatingId] = useState<string | null>(null);
+  const [providerError, setProviderError] = useState<Record<string, string>>(
+    {},
+  );
+
+  const updateProviderKey = useMutation({
+    mutationFn: async ({ id, apiKey }: { id: string; apiKey: string }) => {
+      setMutatingId(id);
+      return api.post<ProviderInfo>(API.CONFIG.PROVIDER_KEY(id), {
+        api_key: apiKey,
+      });
+    },
+    onSuccess: (_data, { id }) => {
+      setKeyInputs((prev) => ({ ...prev, [id]: "" }));
+      setProviderError((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      setMutatingId(null);
+      onSaved();
+      qc.invalidateQueries({ queryKey: queryKeys.providers });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+    onError: (err, { id }) => {
+      setMutatingId(null);
+      const detail = errorToMessage(err, t("failedSaveKey"));
+      setProviderError((prev) => ({ ...prev, [id]: detail }));
+    },
+  });
+
+  const deleteProviderKey = useMutation({
+    mutationFn: async (id: string) => {
+      setMutatingId(id);
+      return api.delete<ProviderInfo>(API.CONFIG.PROVIDER_KEY(id));
+    },
+    onSuccess: () => {
+      setMutatingId(null);
+      qc.invalidateQueries({ queryKey: queryKeys.providers });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+    onError: () => setMutatingId(null),
+  });
+
+  const toggleProvider = useMutation({
+    mutationFn: (id: string) =>
+      api.post<ProviderInfo>(API.CONFIG.PROVIDER_TOGGLE(id)),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.providers });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+  });
+
+  const byokProviders = (providers ?? []).filter(
+    (p) => !p.id.startsWith("custom_"),
+  );
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-[var(--text-secondary)]">{t("byokDesc")}</p>
+
+      {byokProviders.map((p) => (
+        <div
+          key={p.id}
+          className={`rounded-lg border p-3 space-y-2 transition-opacity ${
+            p.is_configured && !p.enabled
+              ? "border-[var(--border-default)] opacity-50"
+              : "border-[var(--border-default)]"
+          }`}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-[var(--text-primary)]">
+              {p.name}
+            </span>
+            <div className="flex items-center gap-2">
+              {p.is_configured && p.enabled && (
+                <span className="text-ui-3xs text-[var(--text-tertiary)]">
+                  {p.model_count} {t("providerModels")}
+                </span>
+              )}
+              {p.is_configured && (
+                <button
+                  type="button"
+                  onClick={() => toggleProvider.mutate(p.id)}
+                  disabled={toggleProvider.isPending}
+                  className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
+                    p.enabled
+                      ? "bg-[var(--color-success)]"
+                      : "bg-[var(--surface-tertiary)]"
+                  }`}
+                  title={
+                    p.enabled ? t("disableProvider") : t("enableProvider")
+                  }
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${
+                      p.enabled ? "translate-x-3" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              )}
+            </div>
+          </div>
+          {p.is_configured && (
+            <div className="flex items-center gap-2 text-xs">
+              <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
+              <span className="text-[var(--text-secondary)] font-mono">
+                {p.masked_key}
+              </span>
+              <button
+                onClick={() => deleteProviderKey.mutate(p.id)}
+                disabled={mutatingId === p.id}
+                className="ml-1 text-[var(--text-tertiary)] hover:text-[var(--color-destructive)] transition-colors"
+                title={t("removeApiKey")}
+              >
+                {mutatingId === p.id ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <X className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+          )}
+          <div className="flex items-start gap-2">
+            <div className="flex-1 space-y-2">
+              <div className="relative">
+                <Input
+                  type={showKey[p.id] ? "text" : "password"}
+                  value={keyInputs[p.id] ?? ""}
+                  onChange={(e) =>
+                    setKeyInputs((prev) => ({
+                      ...prev,
+                      [p.id]: e.target.value,
+                    }))
+                  }
+                  placeholder={t(`providerKeyPlaceholder_${p.id}`, {
+                    defaultValue: `${p.name} API key`,
+                  })}
+                  className="pr-8 font-mono text-xs"
+                  autoComplete="one-time-code"
+                  data-form-type="other"
+                />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setShowKey((prev) => ({
+                      ...prev,
+                      [p.id]: !prev[p.id],
+                    }))
+                  }
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+                >
+                  {showKey[p.id] ? (
+                    <EyeOff className="h-3.5 w-3.5" />
+                  ) : (
+                    <Eye className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                updateProviderKey.mutate({
+                  id: p.id,
+                  apiKey: keyInputs[p.id] ?? "",
+                })
+              }
+              disabled={
+                !(keyInputs[p.id] ?? "").trim() || mutatingId === p.id
+              }
+            >
+              {mutatingId === p.id ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                t("save")
+              )}
+            </Button>
+          </div>
+          {providerError[p.id] && (
+            <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              <span>{providerError[p.id]}</span>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/providers/chatgpt-sub-panel.tsx
+++ b/frontend/src/components/settings/providers/chatgpt-sub-panel.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertCircle, Check, Loader2, LogOut, RotateCw } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api } from "@/lib/api";
+import { API, IS_DESKTOP, queryKeys } from "@/lib/constants";
+import { desktopAPI } from "@/lib/tauri-api";
+import { useSettingsStore } from "@/stores/settings-store";
+import type { ApiKeyStatus } from "@/types/usage";
+
+interface OpenAISubscriptionStatus {
+  is_connected: boolean;
+  email: string;
+  needs_reauth?: boolean;
+}
+
+interface ChatGPTSubPanelProps {
+  /** Used to decide fallback target when disconnecting an active ChatGPT sub. */
+  keyStatus: ApiKeyStatus | undefined;
+}
+
+export function ChatGPTSubPanel({ keyStatus }: ChatGPTSubPanelProps) {
+  const { t } = useTranslation("settings");
+  const qc = useQueryClient();
+  const { activeProvider, setActiveProvider } = useSettingsStore();
+
+  const { data: openaiSubStatus, refetch: refetchOpenaiSub } = useQuery({
+    queryKey: queryKeys.openaiSubscription,
+    queryFn: () =>
+      api.get<OpenAISubscriptionStatus>(API.CONFIG.OPENAI_SUBSCRIPTION),
+  });
+
+  const [polling, setPolling] = useState(false);
+  const [callbackUrlInput, setCallbackUrlInput] = useState("");
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current);
+      pollingIntervalRef.current = null;
+    }
+    if (pollingTimeoutRef.current) {
+      clearTimeout(pollingTimeoutRef.current);
+      pollingTimeoutRef.current = null;
+    }
+    setPolling(false);
+  }, []);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    setPolling(true);
+    let consecutiveFailures = 0;
+    const interval = setInterval(async () => {
+      try {
+        const status = await api.get<OpenAISubscriptionStatus>(
+          API.CONFIG.OPENAI_SUBSCRIPTION,
+        );
+        consecutiveFailures = 0;
+        if (status.is_connected) {
+          stopPolling();
+          refetchOpenaiSub();
+          setActiveProvider("chatgpt");
+          qc.invalidateQueries({ queryKey: queryKeys.models });
+        }
+      } catch (err) {
+        consecutiveFailures += 1;
+        console.warn("OpenAI subscription auth polling failed", err);
+        if (consecutiveFailures >= 3) {
+          stopPolling();
+        }
+      }
+    }, 2000);
+    pollingIntervalRef.current = interval;
+    pollingTimeoutRef.current = setTimeout(stopPolling, 300_000);
+  }, [qc, refetchOpenaiSub, setActiveProvider, stopPolling]);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const openaiDisconnectMutation = useMutation({
+    mutationFn: () => api.delete(API.CONFIG.OPENAI_SUBSCRIPTION),
+    onSuccess: () => {
+      refetchOpenaiSub();
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+      if (activeProvider === "chatgpt") {
+        if (keyStatus?.is_configured) setActiveProvider("byok");
+        else setActiveProvider(null);
+      }
+    },
+  });
+
+  const openaiLoginMutation = useMutation({
+    mutationFn: async () => {
+      const resp = await api.post<{ auth_url: string }>(
+        API.CONFIG.OPENAI_SUBSCRIPTION_LOGIN,
+        {},
+      );
+      if (IS_DESKTOP) await desktopAPI.openExternal(resp.auth_url);
+      else window.open(resp.auth_url, "_blank", "noopener,noreferrer");
+    },
+    onSuccess: startPolling,
+    onError: stopPolling,
+  });
+
+  const manualCallbackMutation = useMutation({
+    mutationFn: () =>
+      api.post<{ success: boolean; email: string }>(
+        API.CONFIG.OPENAI_SUBSCRIPTION_MANUAL_CALLBACK,
+        { callback_url: callbackUrlInput },
+      ),
+    onSuccess: () => {
+      setCallbackUrlInput("");
+      stopPolling();
+      setActiveProvider("chatgpt");
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+  });
+
+  return (
+    <div>
+      <p className="text-xs text-[var(--text-secondary)] mb-3">
+        {t("chatgptSubscriptionDesc")}
+      </p>
+      {openaiSubStatus?.is_connected ? (
+        <div className="space-y-3">
+          <div
+            className={`rounded-lg border p-3 ${openaiSubStatus.needs_reauth ? "border-[var(--color-warning)]" : "border-[var(--border-default)]"}`}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {openaiSubStatus.needs_reauth ? (
+                  <AlertCircle className="h-3.5 w-3.5 text-[var(--color-warning)]" />
+                ) : (
+                  <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
+                )}
+                <span className="text-xs text-[var(--text-secondary)]">
+                  {openaiSubStatus.email || t("chatgptConnected")}
+                </span>
+              </div>
+              <span
+                className={`text-xs font-medium ${openaiSubStatus.needs_reauth ? "text-[var(--color-warning)]" : "text-[var(--color-success)]"}`}
+              >
+                {openaiSubStatus.needs_reauth
+                  ? t("chatgptNeedsReauth")
+                  : t("chatgptActive")}
+              </span>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            {openaiSubStatus.needs_reauth && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => openaiLoginMutation.mutate()}
+                disabled={openaiLoginMutation.isPending || polling}
+              >
+                {openaiLoginMutation.isPending || polling ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                ) : (
+                  <RotateCw className="h-3.5 w-3.5 mr-1.5" />
+                )}
+                {t("chatgptSignIn")}
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => openaiDisconnectMutation.mutate()}
+              disabled={openaiDisconnectMutation.isPending}
+            >
+              {openaiDisconnectMutation.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+              ) : (
+                <LogOut className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              {t("disconnect")}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => openaiLoginMutation.mutate()}
+            disabled={openaiLoginMutation.isPending || polling}
+          >
+            {openaiLoginMutation.isPending || polling ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+            ) : null}
+            {polling ? t("chatgptWaiting") : t("chatgptSignIn")}
+          </Button>
+          {openaiLoginMutation.isError && (
+            <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              <span>{t("chatgptLoginFailed")}</span>
+            </div>
+          )}
+          {polling && (
+            <div className="space-y-2 pt-2">
+              <p className="text-xs text-[var(--text-secondary)]">
+                {t("chatgptPasteInstruction")}
+              </p>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="text"
+                  value={callbackUrlInput}
+                  onChange={(e) => setCallbackUrlInput(e.target.value)}
+                  placeholder={t("chatgptPastePlaceholder")}
+                  className="font-mono text-xs"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => manualCallbackMutation.mutate()}
+                  disabled={
+                    !callbackUrlInput.trim() ||
+                    manualCallbackMutation.isPending
+                  }
+                >
+                  {manualCallbackMutation.isPending ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    t("chatgptSubmitCallback")
+                  )}
+                </Button>
+              </div>
+              {manualCallbackMutation.isError && (
+                <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                  <span>{t("chatgptManualCallbackFailed")}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/providers/custom-endpoint-form.tsx
+++ b/frontend/src/components/settings/providers/custom-endpoint-form.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, Eye, EyeOff, Loader2 } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { api, ApiError } from "@/lib/api";
+import { errorToMessage } from "@/lib/errors";
+import { API, queryKeys } from "@/lib/constants";
+import type { ProviderInfo } from "@/types/usage";
+
+function extractApiDetail(err: unknown, fallback: string): string {
+  if (!(err instanceof ApiError)) return fallback;
+  return errorToMessage(err, fallback);
+}
+
+/**
+ * "Add new custom endpoint" form. Owns its own input state; on success the
+ * fields reset and the providers/models queries invalidate so the parent
+ * panel re-renders its saved-endpoint list.
+ */
+export function CustomEndpointForm() {
+  const { t } = useTranslation("settings");
+  const qc = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createEndpoint = useMutation({
+    mutationFn: () =>
+      api.post<ProviderInfo>(API.CONFIG.CUSTOM_ENDPOINT, {
+        name: name || "Custom Endpoint",
+        api_key: apiKey,
+        base_url: baseUrl,
+      }),
+    onSuccess: () => {
+      setName("");
+      setBaseUrl("");
+      setApiKey("");
+      setError(null);
+      qc.invalidateQueries({ queryKey: queryKeys.providers });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+    onError: (err) => {
+      setError(extractApiDetail(err, "Failed to save endpoint"));
+    },
+  });
+
+  return (
+    <div className="space-y-4 pt-4 border-t border-[var(--border-primary)]">
+      <h4 className="text-xs font-semibold text-[var(--text-secondary)]">
+        {t("addNewCustomEndpoint")}
+      </h4>
+      <div className="space-y-3 p-3 bg-[var(--surface-secondary)] rounded-lg">
+        <Input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t("endpointNamePlaceholder")}
+          className="text-xs bg-[var(--surface-primary)]"
+        />
+        <Input
+          type="text"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+          placeholder={t("providerUrlPlaceholder_custom", {
+            defaultValue: "Base URL (e.g. https://api.myendpoint.com/v1)",
+          })}
+          className="font-mono text-xs bg-[var(--surface-primary)]"
+        />
+        <div className="relative">
+          <Input
+            type={showKey ? "text" : "password"}
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={t("apiKeyPlaceholderOptional")}
+            className="pr-8 font-mono text-xs bg-[var(--surface-primary)]"
+            autoComplete="one-time-code"
+          />
+          <button
+            type="button"
+            onClick={() => setShowKey((prev) => !prev)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+          >
+            {showKey ? (
+              <EyeOff className="h-3.5 w-3.5" />
+            ) : (
+              <Eye className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
+        <div className="flex items-center justify-between">
+          {error && (
+            <div className="flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+          <Button
+            variant="default"
+            size="sm"
+            className="ml-auto"
+            onClick={() => createEndpoint.mutate()}
+            disabled={!baseUrl.trim() || createEndpoint.isPending}
+          >
+            {createEndpoint.isPending ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" />
+            ) : null}
+            {t("addEndpoint")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/providers/custom-endpoint-panel.tsx
+++ b/frontend/src/components/settings/providers/custom-endpoint-panel.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, Loader2, LogOut } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { api, ApiError } from "@/lib/api";
+import { errorToMessage } from "@/lib/errors";
+import { API, queryKeys } from "@/lib/constants";
+import type { LocalProviderStatus, ProviderInfo } from "@/types/usage";
+import { CustomEndpointForm } from "@/components/settings/providers/custom-endpoint-form";
+
+function extractApiDetail(err: unknown, fallback: string): string {
+  if (!(err instanceof ApiError)) return fallback;
+  return errorToMessage(err, fallback);
+}
+
+interface CustomEndpointPanelProps {
+  providers: ProviderInfo[] | undefined;
+  localStatus: LocalProviderStatus | undefined;
+  /** Invoked after the legacy local provider is deleted, so parent can fall back. */
+  onLocalDeleted: () => void;
+}
+
+export function CustomEndpointPanel({
+  providers,
+  localStatus,
+  onLocalDeleted,
+}: CustomEndpointPanelProps) {
+  const { t } = useTranslation("settings");
+  const qc = useQueryClient();
+
+  const [mutatingId, setMutatingId] = useState<string | null>(null);
+  const [providerError, setProviderError] = useState<Record<string, string>>(
+    {},
+  );
+
+  const deleteCustomEndpoint = useMutation({
+    mutationFn: async (id: string) => {
+      setMutatingId(id);
+      return api.delete<ProviderInfo>(API.CONFIG.CUSTOM_ENDPOINT_ITEM(id));
+    },
+    onSuccess: () => {
+      setMutatingId(null);
+      qc.invalidateQueries({ queryKey: queryKeys.providers });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+    onError: () => setMutatingId(null),
+  });
+
+  const updateCustomEndpoint = useMutation({
+    mutationFn: async ({
+      id,
+      enabled,
+    }: {
+      id: string;
+      enabled?: boolean;
+    }) => {
+      setMutatingId(id);
+      const body: Record<string, unknown> = {};
+      if (enabled !== undefined) body.enabled = enabled;
+      return api.patch<ProviderInfo>(
+        API.CONFIG.CUSTOM_ENDPOINT_ITEM(id),
+        body,
+      );
+    },
+    onSuccess: () => {
+      setMutatingId(null);
+      qc.invalidateQueries({ queryKey: queryKeys.providers });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+    },
+    onError: (err, { id }) => {
+      setMutatingId(null);
+      setProviderError((prev) => ({
+        ...prev,
+        [id]: extractApiDetail(err, "Failed to update endpoint"),
+      }));
+    },
+  });
+
+  const deleteLocalProvider = useMutation({
+    mutationFn: () =>
+      api.delete<LocalProviderStatus>(API.CONFIG.LOCAL_PROVIDER),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.localProvider });
+      qc.invalidateQueries({ queryKey: queryKeys.models });
+      setProviderError((prev) => {
+        const next = { ...prev };
+        delete next["local_legacy"];
+        return next;
+      });
+      onLocalDeleted();
+    },
+    onError: (err) => {
+      const detail = errorToMessage(err, t("failedSaveKey"));
+      setProviderError((prev) => ({ ...prev, ["local_legacy"]: detail }));
+    },
+  });
+
+  const customProviders =
+    providers?.filter((p) => p.id.startsWith("custom_")) ?? [];
+  const hasLegacyLocal = !!localStatus?.is_configured;
+
+  return (
+    <div className="space-y-6">
+      <p className="text-xs text-[var(--text-secondary)]">
+        {t("customEndpointDesc")}
+      </p>
+
+      {(hasLegacyLocal || customProviders.length > 0) && (
+        <div className="space-y-4">
+          <h4 className="text-xs font-semibold text-[var(--text-secondary)]">
+            {t("savedEndpoints")}
+          </h4>
+          {hasLegacyLocal && (
+            <div
+              className={`p-3 border border-[var(--border-primary)] rounded-lg bg-[var(--surface-secondary)] ${localStatus?.status === "error" ? "border-[var(--color-destructive)]/40" : ""}`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex min-w-0 items-center gap-2 text-xs">
+                  <span className="font-semibold">{t("localProvider")}</span>
+                  <span className="text-[var(--text-secondary)] font-mono ml-2 text-ui-3xs bg-[var(--surface-primary)] px-2 py-0.5 rounded truncate">
+                    {localStatus?.base_url}
+                  </span>
+                  {localStatus?.status === "error" && (
+                    <span className="text-[var(--color-destructive)] text-ui-3xs">
+                      {t("localProviderConnectError")}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-[var(--color-destructive)] hover:text-[var(--color-destructive)] hover:bg-[var(--color-destructive)]/10"
+                    onClick={() => deleteLocalProvider.mutate()}
+                    disabled={deleteLocalProvider.isPending}
+                  >
+                    {deleteLocalProvider.isPending ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <LogOut className="h-3 w-3" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+              {providerError["local_legacy"] && (
+                <div className="mt-2 flex items-center gap-1.5 text-xs text-[var(--color-destructive)]">
+                  <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                  <span>{providerError["local_legacy"]}</span>
+                </div>
+              )}
+            </div>
+          )}
+          {customProviders.map((p) => (
+            <div
+              key={p.id}
+              className={`p-3 border border-[var(--border-primary)] rounded-lg bg-[var(--surface-secondary)] ${!p.enabled ? "opacity-50" : ""}`}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 text-xs">
+                  <span className="font-semibold">
+                    {p.name || t("customEndpoint")}
+                  </span>
+                  <span className="text-[var(--text-secondary)] font-mono ml-2 text-ui-3xs bg-[var(--surface-primary)] px-2 py-0.5 rounded">
+                    {p.base_url}
+                  </span>
+                  {p.masked_key && (
+                    <span className="text-[var(--text-tertiary)] font-mono ml-2 text-ui-3xs">
+                      Key: {p.masked_key}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-ui-3xs text-[var(--text-tertiary)]">
+                    {p.model_count} models
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      updateCustomEndpoint.mutate({
+                        id: p.id,
+                        enabled: !p.enabled,
+                      })
+                    }
+                    disabled={updateCustomEndpoint.isPending}
+                    className={`relative inline-flex h-4 w-7 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
+                      p.enabled
+                        ? "bg-[var(--color-success)]"
+                        : "bg-[var(--surface-tertiary)]"
+                    }`}
+                    title={
+                      p.enabled
+                        ? t("disableProvider")
+                        : t("enableProvider")
+                    }
+                  >
+                    <span
+                      className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-sm transition-transform ${
+                        p.enabled ? "translate-x-3" : "translate-x-0"
+                      }`}
+                    />
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-[var(--color-destructive)] hover:text-[var(--color-destructive)] hover:bg-[var(--color-destructive)]/10"
+                    onClick={() => deleteCustomEndpoint.mutate(p.id)}
+                    disabled={mutatingId === p.id}
+                  >
+                    {mutatingId === p.id ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <LogOut className="h-3 w-3" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <CustomEndpointForm />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #102.

## Summary

Pure structural extraction on [frontend/src/components/settings/providers-tab.tsx](https://github.com/openyak/openyak/blob/refactor/providers-tab-split/frontend/src/components/settings/providers-tab.tsx) — zero behavior change. The 1021-line file collapses to 257 lines of layout + mode-card grid + panel delegation; the three remaining mode panels move to their own files. Ollama and Rapid-MLX panels were already extracted.

| | Before | After | Spec |
|---|---:|---:|---:|
| \`providers-tab.tsx\` | 1021 | **257** | ≤200 |
| \`byok-panel.tsx\` | (inline) | 215 | ≤250 |
| \`chatgpt-sub-panel.tsx\` | (inline) | 246 | ≤250 |
| \`custom-endpoint-panel.tsx\` | (inline) | 228 | ≤250 |
| \`custom-endpoint-form.tsx\` | (inline) | 120 | — |

Total lines: 1021 → 1066 (+45), as the cost of explicit prop boundaries + a new-endpoint form lifted out for symmetry. The parent's 257 is slightly over the 200 target because it legitimately owns six queries that drive both the card-grid \"connected\" badges and the conditional panel rendering — but the parent is now flat orchestration, not a 600-line conditional JSX tree.

## New files under \`frontend/src/components/settings/providers/\`

- **\`byok-panel.tsx\`** — BYOK provider list (OpenRouter / OpenAI / Anthropic / Gemini / etc.); owns \`keyInputs\` / \`showKey\` / \`mutatingId\` state and \`updateProviderKey\` / \`deleteProviderKey\` / \`toggleProvider\` mutations.
- **\`chatgpt-sub-panel.tsx\`** — OAuth login + 2s polling + 5min timeout + manual callback paste + disconnect; owns polling refs and \`callbackUrlInput\` state.
- **\`custom-endpoint-panel.tsx\`** — Saved-endpoint list + delete/toggle + delete legacy local provider; orchestrates the saved list and embeds \`<CustomEndpointForm />\`.
- **\`custom-endpoint-form.tsx\`** — Add-new-endpoint form; fully self-contained (name / base URL / API key inputs + \`createEndpoint\` mutation).

## State migration

Each panel owns the input state and mutations scoped to its concern. The parent passes only the data needed for panel rendering (\`providers\`, \`localStatus\`, \`keyStatus\`). React Query cache deduplicates the shared queries between parent (badge computation) and children (panel rendering).

## Out of scope

- No new state-management additions (no Zustand additions, no Jotai).
- No visual changes — same i18n keys, same DOM structure, same styling, same icon set.
- No changes to API endpoints or query keys.
- \`OllamaPanel\` / \`RapidMLXPanel\` already lived in their own files; left alone.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx next lint --dir src/components/settings\` — no warnings or errors
- [ ] Manual: switch between all 5 provider modes; add/delete a BYOK key; OAuth login flow renders + polls + accepts manual callback paste; add/delete/toggle a custom endpoint
- [ ] Playwright UI sweep (no \`providers-tab\` specific test exists today, but the broader settings flows in \`openyak-deep-surfaces.spec.ts\` cover the page)