### PR TITLE
chore(custom-provider): quickwin polish from #109

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -658,7 +658,10 @@ async def create_custom_endpoint(
 
     registry.register(test_provider)
     try:
-        await registry.refresh_models()
+        # Only refresh this provider — the BYOK/Ollama/Rapid-MLX providers
+        # don't change when we add a custom endpoint, so the full sweep
+        # was waste.
+        await registry.refresh_provider(endpoint_id)
     except Exception as e:
         logger.warning("Failed to refresh models after adding custom endpoint %s: %s", endpoint_id, e)
 
@@ -722,12 +725,15 @@ async def update_custom_endpoint(
     # Any change to fields that flow into the provider constructor requires
     # rebuilding. Also rebuild when re-enabling a previously disabled
     # endpoint — the toggle-off path explicitly unregisters the provider,
-    # so the on-path has to put it back.
+    # so the on-path has to put it back. An empty ``headers`` delta (``{}``)
+    # is treated as no-change so well-meaning clients that always send the
+    # field don't trigger a wasted rebuild + /v1/models call.
+    headers_delta_has_changes = bool(body.headers)
     needs_rebuild = (
         body.base_url is not None
         or body.api_key is not None
         or body.models is not None
-        or body.headers is not None
+        or headers_delta_has_changes
         or (enabled and not prev_enabled)
     )
     if body.models is not None:
@@ -796,7 +802,8 @@ async def update_custom_endpoint(
         registry.unregister(endpoint_id)
         registry.register(test_provider)
         try:
-            await registry.refresh_models()
+            # Single-provider refresh — see create_custom_endpoint above.
+            await registry.refresh_provider(endpoint_id)
         except Exception as e:
             logger.warning("Failed to refresh models after updating custom endpoint %s: %s", endpoint_id, e)
     elif not enabled:

--- a/frontend/src/components/settings/providers/custom-endpoint-edit-form.tsx
+++ b/frontend/src/components/settings/providers/custom-endpoint-edit-form.tsx
@@ -464,7 +464,10 @@ export function CustomEndpointEditForm({
             if (row.kind === "existing") {
               return (
                 <div key={`existing-${row.name}`} className="flex items-center gap-2">
-                  <div className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-[var(--surface-primary)] border border-[var(--border-primary)] text-xs font-mono text-[var(--text-tertiary)]">
+                  <div
+                    className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-[var(--surface-primary)] border border-[var(--border-primary)] text-xs font-mono text-[var(--text-tertiary)]"
+                    title={row.name}
+                  >
                     <Lock className="h-3 w-3 shrink-0" />
                     <span className="truncate">{row.name}</span>
                   </div>

--- a/frontend/src/components/settings/rapid-mlx-panel.tsx
+++ b/frontend/src/components/settings/rapid-mlx-panel.tsx
@@ -322,7 +322,19 @@ export function RapidMLXPanel() {
                     setUninstallResult(null);
                     setUninstallOpen(true);
                   }}
-                  title="Uninstall Rapid-MLX from OpenYak"
+                  disabled={
+                    stopMutation.isPending ||
+                    startMutation.isPending ||
+                    removeMutation.isPending ||
+                    uninstallMutation.isPending
+                  }
+                  title={
+                    stopMutation.isPending
+                      ? "Wait for the current stop to finish"
+                      : startMutation.isPending
+                        ? "Wait for the current start to finish"
+                        : "Uninstall Rapid-MLX from OpenYak"
+                  }
                 >
                   <PowerOff className="mr-1 h-3 w-3" />
                   Uninstall

--- a/frontend/src/components/settings/rapid-mlx-panel.tsx
+++ b/frontend/src/components/settings/rapid-mlx-panel.tsx
@@ -333,7 +333,9 @@ export function RapidMLXPanel() {
                       ? "Wait for the current stop to finish"
                       : startMutation.isPending
                         ? "Wait for the current start to finish"
-                        : "Uninstall Rapid-MLX from OpenYak"
+                        : removeMutation.isPending
+                          ? "Wait for the model removal to finish"
+                          : "Uninstall Rapid-MLX from OpenYak"
                   }
                 >
                   <PowerOff className="mr-1 h-3 w-3" />


### PR DESCRIPTION
## Summary

Knock out the four fast-wins from #109 (the PR #108 review follow-up checklist).

- `refresh_provider(pid)` consistency in POST + PATCH `/config/custom` — was still doing the full cross-provider sweep, even though heal-on-read had moved past it
- PATCH short-circuits on empty headers delta `{}` — merge-patch semantics already treat it as no-op; now we skip the rebuild + /v1/models call instead of just doing them for nothing
- Edit form: `title` attribute on existing-header name chips so long names show their full value on hover
- Rapid-MLX Uninstall button: disabled when start/stop/remove are in flight (Stop was the obvious race; the others are for symmetry)

Closes 4 of 8 items in #109 (the remaining 4 are medium-effort and tracked there).

## Test plan

- [ ] Create a custom endpoint — confirm registry refresh logs show only the new endpoint, no cross-provider sweep
- [ ] Edit a custom endpoint with `headers: {}` in the payload (e.g. via direct API call) — confirm no rebuild / no /v1/models call
- [ ] Edit form with a long header name — hover the locked name chip, full name shows in tooltip
- [ ] Click Uninstall while a Stop request is mid-flight — Uninstall button is disabled with a "Wait for the current stop to finish" tooltip