### PR TITLE
fix(custom-provider): value-equality needs_rebuild + dup-name guard + undo

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -716,38 +716,28 @@ async def update_custom_endpoint(
         if not found:
             raise HTTPException(404, "Custom endpoint not found")
 
-    name = body.name.strip() if body.name is not None else found.get("name", "Custom Endpoint")
-    base_url = body.base_url if body.base_url is not None else found.get("base_url", "")
-    api_key = body.api_key.strip() if body.api_key is not None else found.get("api_key", "")
-    enabled = body.enabled if body.enabled is not None else found.get("enabled", True)
+    existing_base_url = found.get("base_url", "")
+    existing_api_key = found.get("api_key", "")
+    existing_models = list(found.get("models") or [])
+    existing_headers: dict[str, str] = dict(found.get("headers") or {})
     prev_enabled = bool(found.get("enabled", True))
 
-    # Any change to fields that flow into the provider constructor requires
-    # rebuilding. Also rebuild when re-enabling a previously disabled
-    # endpoint — the toggle-off path explicitly unregisters the provider,
-    # so the on-path has to put it back. An empty ``headers`` delta (``{}``)
-    # is treated as no-change so well-meaning clients that always send the
-    # field don't trigger a wasted rebuild + /v1/models call.
-    headers_delta_has_changes = bool(body.headers)
-    needs_rebuild = (
-        body.base_url is not None
-        or body.api_key is not None
-        or body.models is not None
-        or headers_delta_has_changes
-        or (enabled and not prev_enabled)
-    )
+    name = body.name.strip() if body.name is not None else found.get("name", "Custom Endpoint")
+    base_url = body.base_url if body.base_url is not None else existing_base_url
+    api_key = body.api_key.strip() if body.api_key is not None else existing_api_key
+    enabled = body.enabled if body.enabled is not None else found.get("enabled", True)
+
     if body.models is not None:
         models_payload = [{"id": m.id, "name": m.name} for m in body.models]
     else:
-        models_payload = list(found.get("models") or [])
+        models_payload = list(existing_models)
+
     # Headers follow JSON Merge Patch semantics on PATCH — body.headers is
-    # a delta, never a full replacement. This stops the edit form's
-    # masked round-trip (we mask values on GET, so we can't safely echo
-    # them back on save) from silently wiping headers the user hasn't
-    # touched.
-    existing_headers: dict[str, str] = dict(found.get("headers") or {})
+    # a delta, never a full replacement. We mask values on GET, so the
+    # frontend can't safely echo them back; instead it only sends keys it
+    # explicitly changed.
     if body.headers is None:
-        headers_payload = existing_headers
+        headers_payload = dict(existing_headers)
     else:
         headers_payload = dict(existing_headers)
         for key, value in body.headers.items():
@@ -755,6 +745,20 @@ async def update_custom_endpoint(
                 headers_payload.pop(key, None)
             else:
                 headers_payload[key] = value
+
+    # Only rebuild the provider when a constructor-relevant field's
+    # *effective value* actually changed — comparing against the stored
+    # config avoids wasted /v1/models calls when the client always sends
+    # all fields (e.g. the edit form re-sends base_url even when the user
+    # only edited Display name). Re-enabling a previously disabled
+    # endpoint also rebuilds, because toggle-off explicitly unregisters.
+    needs_rebuild = (
+        base_url != existing_base_url
+        or api_key != existing_api_key
+        or models_payload != existing_models
+        or headers_payload != existing_headers
+        or (enabled and not prev_enabled)
+    )
 
     # --- Phase 2: validate (outside lock — network I/O) ---
     if needs_rebuild:

--- a/frontend/src/components/settings/providers/custom-endpoint-edit-form.tsx
+++ b/frontend/src/components/settings/providers/custom-endpoint-edit-form.tsx
@@ -175,6 +175,37 @@ export function CustomEndpointEditForm({
       payload.api_key = apiKey.trim();
     }
 
+    // Validate new-row names: reject duplicates among new rows, and
+    // duplicates that collide with a still-present existing row. (A
+    // collision with a *deleted* existing row is also blocked — if the
+    // user wants to "rename" the same header in place, they should
+    // re-enter the value on the existing row instead.) Without this
+    // check, the dict-based delta below would silently last-write-wins
+    // and the user would lose the earlier entry without warning.
+    const newNamesSeen = new Set<string>();
+    const existingNames = new Set(
+      headerRows.flatMap((r) =>
+        r.kind === "existing" ? [r.name.toLowerCase()] : [],
+      ),
+    );
+    for (const row of headerRows) {
+      if (row.kind !== "new") continue;
+      const n = row.name.trim();
+      if (n.length === 0) continue;
+      const lower = n.toLowerCase();
+      if (newNamesSeen.has(lower) || existingNames.has(lower)) {
+        setError(
+          t("customHeaderDuplicate", {
+            defaultValue:
+              "Header \"{{name}}\" is listed more than once. Header names must be unique.",
+            name: n,
+          }),
+        );
+        return;
+      }
+      newNamesSeen.add(lower);
+    }
+
     // Build a JSON Merge Patch delta — untouched existing rows are
     // omitted, so they survive on the backend even if the user only
     // changed one header. ``null`` marks a deletion.
@@ -243,15 +274,23 @@ export function CustomEndpointEditForm({
       const row = prev[idx];
       if (!row) return prev;
       if (row.kind === "existing") {
-        // Mark for deletion but keep the row out of the visual list so
-        // the user can keep adding new rows. The deleted name still
-        // contributes a ``null`` to the submit delta.
+        // Mark for deletion. The row stays in state and is still
+        // rendered (with strikethrough + Undo) so the user can revert
+        // without cancelling the whole edit. Submit converts deleted=true
+        // into a ``null`` entry in the headers delta.
         return prev.map((r, i) =>
           i === idx && r.kind === "existing" ? { ...r, deleted: true } : r,
         );
       }
       return prev.filter((_, i) => i !== idx);
     });
+  };
+  const undoDeleteHeader = (idx: number) => {
+    setHeaderRows((prev) =>
+      prev.map((r, i) =>
+        i === idx && r.kind === "existing" ? { ...r, deleted: false } : r,
+      ),
+    );
   };
 
   const submitDisabled = !baseUrl.trim() || updateEndpoint.isPending;
@@ -459,7 +498,33 @@ export function CustomEndpointEditForm({
         <div className="space-y-2">
           {headerRows.map((row, idx) => {
             if (row.kind === "existing" && row.deleted) {
-              return null;
+              return (
+                <div
+                  key={`existing-${row.name}`}
+                  className="flex items-center gap-2 opacity-60"
+                >
+                  <div
+                    className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-md bg-[var(--surface-primary)] border border-[var(--border-primary)] text-xs font-mono text-[var(--text-tertiary)]"
+                    title={row.name}
+                  >
+                    <Lock className="h-3 w-3 shrink-0" />
+                    <span className="truncate line-through">{row.name}</span>
+                  </div>
+                  <div className="flex flex-1 items-center text-ui-3xs text-[var(--color-destructive)]">
+                    {t("customHeaderDeletedHint", {
+                      defaultValue:
+                        "Will be removed on save.",
+                    })}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => undoDeleteHeader(idx)}
+                    className="text-ui-3xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] underline-offset-2 hover:underline px-1"
+                  >
+                    {t("undo", { defaultValue: "Undo" })}
+                  </button>
+                </div>
+              );
             }
             if (row.kind === "existing") {
               return (

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -275,6 +275,8 @@
   "customHeaderValueExistingPlaceholder": "{{masked}} (leave blank to keep)",
   "customHeadersEditHint": "Leave a value blank to keep it. Trash deletes the header. Add new rows below.",
   "customHeaderDeleteTitle": "Delete this header",
+  "customHeaderDeletedHint": "Will be removed on save.",
+  "customHeaderDuplicate": "Header \"{{name}}\" is listed more than once. Header names must be unique.",
   "customBaseUrlRequired": "Base URL is required.",
   "editProvider": "Edit provider",
   "cancel": "Cancel",

--- a/frontend/src/i18n/locales/zh/settings.json
+++ b/frontend/src/i18n/locales/zh/settings.json
@@ -275,6 +275,8 @@
   "customHeaderValueExistingPlaceholder": "{{masked}}（留空保持不变）",
   "customHeadersEditHint": "留空保留原值，垃圾桶删除该 header，下方可继续添加新行。",
   "customHeaderDeleteTitle": "删除此 header",
+  "customHeaderDeletedHint": "保存后将被删除。",
+  "customHeaderDuplicate": "Header \"{{name}}\" 重复出现，header 名必须唯一。",
   "customBaseUrlRequired": "Base URL 不能为空。",
   "editProvider": "编辑 Provider",
   "cancel": "取消",


### PR DESCRIPTION
## Summary

Three remaining behavioural items from #109. No new endpoints, no schema changes.

- **\`needs_rebuild\` now compares effective values to stored values** instead of treating any field's presence as a change. Display-name-only edits no longer rebuild the provider (so no more wasted \`/v1/models\` calls on auto-discover endpoints), and same-value resends on headers / models / base_url / api_key are also free.
- **Header-name uniqueness validated on submit** — case-insensitive, covers both dup-among-new-rows and new-row-clashes-with-existing. Without this, the dict-based delta would silently last-write-wins.
- **Soft-deleted header rows now render** at 60% opacity with strikethrough + Undo button. The previous behaviour hid them entirely so the only recovery was Cancel + reopen.

Closes 3 of the 4 remaining items in #109. Tests (item 4) still open.

## Test plan

- [ ] Edit a custom endpoint and change only Display name → registry logs should NOT show \`Refreshed provider X\` (no rebuild)
- [ ] Edit + change base_url → rebuild happens, \`/v1/models\` call visible in logs
- [ ] Edit headers, add two new rows named \`X-Region\` → submit shows inline error "Header \"X-Region\" is listed more than once"
- [ ] Edit headers, add new row named \`X-Org\` while existing \`X-Org\` is still present → same error
- [ ] Edit headers, trash an existing header → row stays visible with strikethrough + Undo, clicking Undo restores it
- [ ] PATCH \`/config/custom/<id>\` with \`{"headers": {"X-Org": "samevalue"}}\` (same as stored) → backend skips rebuild