### PR TITLE
test(custom-provider): unit coverage for slug, header delta, refresh_provider, uninstall

### DIFF
--- a/backend/tests/test_api/test_custom_endpoint_schema.py
+++ b/backend/tests/test_api/test_custom_endpoint_schema.py
@@ -1,0 +1,232 @@
+"""Tests for the custom-endpoint Pydantic schemas.
+
+Covers slug validation (POST), header validation (POST full-set), and
+the headers JSON Merge Patch delta validation (PATCH).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.provider import (
+    CustomEndpointCreate,
+    CustomEndpointModel,
+    CustomEndpointUpdate,
+    RESERVED_CUSTOM_SLUGS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Slug validation
+# ---------------------------------------------------------------------------
+
+
+class TestSlugValidation:
+    def _make(self, slug: str, **kwargs):
+        return CustomEndpointCreate(
+            slug=slug,
+            name=kwargs.pop("name", "My Provider"),
+            base_url=kwargs.pop("base_url", "https://api.example.com/v1"),
+            **kwargs,
+        )
+
+    def test_simple_slug(self):
+        assert self._make("myprovider").slug == "myprovider"
+
+    def test_alphanumeric(self):
+        assert self._make("groq3").slug == "groq3"
+
+    def test_hyphens_and_underscores(self):
+        assert self._make("my-cool_provider").slug == "my-cool_provider"
+
+    def test_max_length(self):
+        slug = "a" + "b" * 49  # 50 chars total
+        assert self._make(slug).slug == slug
+
+    def test_uppercase_lowered(self):
+        """Mixed case in input is lowered by the validator (after strip)."""
+        # The validator both strips and lowercases before applying the
+        # regex; "Foo" → "foo" is accepted.
+        assert self._make("Foo").slug == "foo"
+
+    def test_surrounding_whitespace_stripped(self):
+        assert self._make("  myslug  ").slug == "myslug"
+
+    @pytest.mark.parametrize("slug", sorted(RESERVED_CUSTOM_SLUGS))
+    def test_rejects_reserved(self, slug: str):
+        with pytest.raises(ValidationError, match="reserved"):
+            self._make(slug)
+
+    @pytest.mark.parametrize(
+        "slug",
+        [
+            "-leading-hyphen",      # starts with hyphen
+            "_leading-underscore",  # starts with underscore
+            "has space",            # space
+            "has:colon",            # colon
+            "has/slash",            # slash
+            "has.dot",              # dot
+            "has@at",               # @
+            "你好",                 # non-ASCII
+            "a" * 51,               # too long
+            "",                     # empty (Field min_length=1)
+        ],
+    )
+    def test_rejects_invalid_format(self, slug: str):
+        with pytest.raises(ValidationError):
+            self._make(slug)
+
+    def test_pdef_catalog_keys_are_reserved(self):
+        """Every BYOK provider id must round-trip into the reserved set,
+        so a user can't accidentally shadow a built-in provider."""
+        from app.provider.catalog import PROVIDER_CATALOG
+        for pid in PROVIDER_CATALOG:
+            with pytest.raises(ValidationError, match="reserved"):
+                self._make(pid)
+
+
+# ---------------------------------------------------------------------------
+# Header validation — full-set semantics on POST
+# ---------------------------------------------------------------------------
+
+
+def _make_create(**kwargs) -> CustomEndpointCreate:
+    return CustomEndpointCreate(
+        slug=kwargs.pop("slug", "myprovider"),
+        name=kwargs.pop("name", "My Provider"),
+        base_url=kwargs.pop("base_url", "https://api.example.com/v1"),
+        **kwargs,
+    )
+
+
+class TestHeadersCreate:
+    def test_empty_dict(self):
+        assert _make_create(headers={}).headers == {}
+
+    def test_default_empty(self):
+        assert _make_create().headers == {}
+
+    def test_basic_pair(self):
+        body = _make_create(headers={"X-Org": "acme"})
+        assert body.headers == {"X-Org": "acme"}
+
+    def test_strips_surrounding_whitespace_in_name(self):
+        body = _make_create(headers={"  X-Org  ": "acme"})
+        assert "X-Org" in body.headers
+
+    @pytest.mark.parametrize("forbidden", ["host", "Host", "HOST", "Content-Length", "transfer-encoding"])
+    def test_rejects_forbidden_names(self, forbidden: str):
+        with pytest.raises(ValidationError, match="reserved"):
+            _make_create(headers={forbidden: "x"})
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "X Bad",   # space
+            "X:Bad",   # colon
+            "X\nBad",  # newline
+            "X\rBad",  # carriage return
+            "X\tBad",  # tab
+            "",        # empty
+        ],
+    )
+    def test_rejects_bad_name_chars(self, bad_name: str):
+        with pytest.raises(ValidationError):
+            _make_create(headers={bad_name: "x"})
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["line1\nline2", "line1\rline2", "has\0null"],
+    )
+    def test_rejects_control_chars_in_value(self, bad_value: str):
+        with pytest.raises(ValidationError, match="control characters"):
+            _make_create(headers={"X-Bad": bad_value})
+
+    def test_rejects_long_value(self):
+        with pytest.raises(ValidationError, match="4096"):
+            _make_create(headers={"X-Big": "x" * 5000})
+
+    def test_at_length_limit(self):
+        """Exactly 4096 chars should be accepted."""
+        ok = _make_create(headers={"X-Big": "x" * 4096})
+        assert len(ok.headers["X-Big"]) == 4096
+
+    def test_rejects_non_string_value(self):
+        with pytest.raises(ValidationError):
+            _make_create(headers={"X-Org": 42})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Header delta — JSON Merge Patch semantics on PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestHeadersDelta:
+    def test_omitted_field_is_none(self):
+        """When the client doesn't send `headers` at all, the value is
+        None — that's the "no change" signal the PATCH handler reads."""
+        assert CustomEndpointUpdate().headers is None
+
+    def test_empty_dict_kept_empty(self):
+        """`{}` is preserved as-is (semantically: an empty delta, which
+        the handler treats as no-op merge)."""
+        assert CustomEndpointUpdate(headers={}).headers == {}
+
+    def test_upsert_only(self):
+        u = CustomEndpointUpdate(headers={"X-Org": "acme"})
+        assert u.headers == {"X-Org": "acme"}
+
+    def test_delete_only(self):
+        """``null`` value marks the key for deletion."""
+        u = CustomEndpointUpdate(headers={"X-Old": None})
+        assert u.headers == {"X-Old": None}
+
+    def test_mixed_upsert_and_delete(self):
+        u = CustomEndpointUpdate(
+            headers={"X-New": "v", "X-Old": None, "X-Keep": "v2"},
+        )
+        assert u.headers == {"X-New": "v", "X-Old": None, "X-Keep": "v2"}
+
+    def test_delete_does_not_validate_value_length(self):
+        """``None`` skips the value validator — useful so delete-only
+        deltas don't need a body."""
+        u = CustomEndpointUpdate(headers={"X-Big": None})
+        assert u.headers == {"X-Big": None}
+
+    def test_rejects_forbidden_name_even_with_null(self):
+        """A null value still has to obey the name rules."""
+        with pytest.raises(ValidationError, match="reserved"):
+            CustomEndpointUpdate(headers={"Host": None})
+
+    def test_rejects_control_chars_in_upsert_value(self):
+        with pytest.raises(ValidationError, match="control characters"):
+            CustomEndpointUpdate(headers={"X-Bad": "line1\nline2"})
+
+    def test_rejects_long_upsert_value(self):
+        with pytest.raises(ValidationError, match="4096"):
+            CustomEndpointUpdate(headers={"X-Big": "x" * 5000})
+
+
+# ---------------------------------------------------------------------------
+# Models list
+# ---------------------------------------------------------------------------
+
+
+class TestCustomEndpointModel:
+    def test_id_only(self):
+        m = CustomEndpointModel(id="gpt-5")
+        assert m.id == "gpt-5"
+        assert m.name is None
+
+    def test_id_and_name(self):
+        m = CustomEndpointModel(id="gpt-5", name="GPT-5")
+        assert m.name == "GPT-5"
+
+    def test_id_min_length(self):
+        with pytest.raises(ValidationError):
+            CustomEndpointModel(id="")
+
+    def test_id_max_length(self):
+        with pytest.raises(ValidationError):
+            CustomEndpointModel(id="x" * 201)

--- a/backend/tests/test_provider/test_provider_registry.py
+++ b/backend/tests/test_provider/test_provider_registry.py
@@ -102,6 +102,119 @@ class TestRefreshModels:
         assert result["slow"] == []
         assert len(reg.all_models()) == 1
 
+class TestRefreshProvider:
+    """Single-provider refresh — used by heal-on-read so we don't pay
+    cross-provider /v1/models calls for one missing endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_unknown_pid(self):
+        reg = ProviderRegistry()
+        result = await reg.refresh_provider("nope")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_adds_models_for_freshly_registered(self):
+        reg = ProviderRegistry()
+        reg.register(_make_provider("p1", [_model("m1", "p1")]))
+        models = await reg.refresh_provider("p1")
+        assert [m.id for m in models] == ["m1"]
+        assert "m1" in reg._model_index
+        assert reg._model_index["m1"][0].id == "p1"
+
+    @pytest.mark.asyncio
+    async def test_leaves_other_providers_alone(self):
+        reg = ProviderRegistry()
+        reg.register(_make_provider("p1", [_model("m1", "p1")]))
+        reg.register(_make_provider("p2", [_model("m2", "p2")]))
+        await reg.refresh_models()
+
+        # Re-refresh only p1 — p2's models must still be there. Capture
+        # the call count to confirm p2 wasn't list_models'd again.
+        p2 = reg.get_provider("p2")
+        p2.list_models.reset_mock()  # type: ignore[union-attr]
+        p2.clear_cache.reset_mock()  # type: ignore[union-attr]
+        await reg.refresh_provider("p1")
+
+        assert "m1" in reg._model_index
+        assert "m2" in reg._model_index
+        p2.list_models.assert_not_called()  # type: ignore[union-attr]
+        p2.clear_cache.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_direct_beats_aggregator(self):
+        """When a model id exists on both an aggregator and a direct
+        provider, direct should win the index slot — and refresh_provider
+        on the aggregator must not steal it back."""
+        reg = ProviderRegistry()
+        aggregator = _make_provider("openrouter", [_model("shared", "openrouter")])
+        direct = _make_provider("openai", [_model("shared", "openai")])
+        reg.register(aggregator)
+        reg.register(direct)
+        await reg.refresh_models()
+        assert reg._model_index["shared"][0].id == "openai"
+
+        # Refresh the aggregator alone — direct still wins.
+        await reg.refresh_provider("openrouter")
+        assert reg._model_index["shared"][0].id == "openai"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_direct_drops_model(self):
+        """If a direct provider stops exposing a model that an aggregator
+        also serves, the index should fall back to the aggregator on the
+        next refresh_provider call."""
+        reg = ProviderRegistry()
+        aggregator = _make_provider("openrouter", [_model("shared", "openrouter")])
+        direct = _make_provider("openai", [_model("shared", "openai")])
+        reg.register(aggregator)
+        reg.register(direct)
+        await reg.refresh_models()
+        assert reg._model_index["shared"][0].id == "openai"
+
+        # Direct drops the model on next refresh.
+        direct.list_models = AsyncMock(return_value=[])  # type: ignore[union-attr]
+        await reg.refresh_provider("openai")
+
+        assert "shared" in reg._model_index
+        assert reg._model_index["shared"][0].id == "openrouter"
+
+    @pytest.mark.asyncio
+    async def test_drops_removed_models(self):
+        """A model the provider no longer exposes should vanish from the
+        registry even if nothing else serves it."""
+        reg = ProviderRegistry()
+        reg.register(_make_provider("p1", [_model("m1", "p1"), _model("m2", "p1")]))
+        await reg.refresh_models()
+        assert {"m1", "m2"} <= set(reg._model_index.keys())
+
+        p1 = reg.get_provider("p1")
+        p1.list_models = AsyncMock(return_value=[_model("m1", "p1")])  # type: ignore[union-attr]
+        await reg.refresh_provider("p1")
+
+        assert "m1" in reg._model_index
+        assert "m2" not in reg._model_index
+        # _full_models should also be cleaned up
+        assert not any(m.id == "m2" for _, m in reg._full_models)
+
+    @pytest.mark.asyncio
+    async def test_swallows_provider_failure(self):
+        """If list_models raises, refresh_provider returns [] and logs;
+        existing index entries for that provider should remain untouched
+        — we don't have a better state to fall back to."""
+        reg = ProviderRegistry()
+        reg.register(_make_provider("p1", [_model("m1", "p1")]))
+        await reg.refresh_models()
+        assert "m1" in reg._model_index
+
+        p1 = reg.get_provider("p1")
+        p1.list_models = AsyncMock(side_effect=RuntimeError("network down"))  # type: ignore[union-attr]
+        result = await reg.refresh_provider("p1")
+
+        assert result == []
+        # Pre-existing index entry should still be there since the
+        # refresh failed before we mutated anything.
+        assert "m1" in reg._model_index
+
+
 class TestResolveModel:
     @pytest.mark.asyncio
     async def test_existing(self):

--- a/backend/tests/test_rapid_mlx/test_rapid_mlx_manager.py
+++ b/backend/tests/test_rapid_mlx/test_rapid_mlx_manager.py
@@ -187,3 +187,158 @@ async def test_rapid_mlx_start_replaces_managed_process_on_new_port(
             "19000",
         )
     ]
+
+
+# ---------------------------------------------------------------------------
+# uninstall — freed_bytes accounting + HF cache cleanup
+# ---------------------------------------------------------------------------
+
+
+def _make_hf_cache(root: Path) -> Path:
+    """Create a fake HuggingFace hub directory at ``<root>/hub``."""
+    hub = root / "hub"
+    hub.mkdir(parents=True, exist_ok=True)
+    return hub
+
+
+def _make_cached_repo(hub: Path, repo: str, blob_sizes: list[int]) -> Path:
+    """Lay out a model dir mirroring how HF actually structures the cache:
+    ``blobs/<sha>`` are the real files, ``snapshots/<rev>/<name>`` are
+    symlinks pointing at them.
+
+    Returns the model dir.
+    """
+    model_dir = hub / f"models--{repo.replace('/', '--')}"
+    blobs_dir = model_dir / "blobs"
+    blobs_dir.mkdir(parents=True)
+    snapshots_dir = model_dir / "snapshots" / "rev1"
+    snapshots_dir.mkdir(parents=True)
+    refs_dir = model_dir / "refs"
+    refs_dir.mkdir(parents=True)
+    (refs_dir / "main").write_text("rev1", encoding="utf-8")
+
+    for i, size in enumerate(blob_sizes):
+        sha = f"abc{i}"
+        blob = blobs_dir / sha
+        blob.write_bytes(b"\0" * size)
+        # snapshot file is a symlink → blob
+        snap = snapshots_dir / f"file{i}.bin"
+        snap.symlink_to(blob)
+    return model_dir
+
+
+@pytest.mark.asyncio
+async def test_uninstall_filters_symlinks_when_counting_freed_bytes(
+    monkeypatch, tmp_path: Path
+):
+    """HF cache layout uses snapshots/<rev>/file → blobs/<sha> symlinks.
+    rglob+stat follows symlinks, so naively summing every "file" would
+    double-count the real blob through its snapshot pointer. The fix
+    must skip symlinks and count blobs only.
+    """
+    hub = _make_hf_cache(tmp_path)
+    # Two blobs: 1000 + 2500 bytes — both reachable via symlinks too.
+    # Plus the refs/main pointer file (4 bytes — "rev1").
+    target_sizes = [1000, 2500]
+    expected_freed = sum(target_sizes) + len("rev1")
+
+    # Use the first known alias from the catalog so resolve_rapid_mlx_repo
+    # produces a stable repo path.
+    from app.rapid_mlx.catalog import RAPID_MLX_ALIAS_REPOS, resolve_rapid_mlx_repo
+
+    target_alias = next(iter(RAPID_MLX_ALIAS_REPOS))
+    target_repo = resolve_rapid_mlx_repo(target_alias)
+    _make_cached_repo(hub, target_repo, target_sizes)
+    naive_double = sum(target_sizes) * 2 + len("rev1")
+
+    monkeypatch.setattr(manager_module, "_huggingface_cache_dir", lambda: hub)
+    # Treat the binary as already gone — uninstall.stop() should no-op
+    # cleanly (nothing is running) and we focus on the cleanup path.
+    monkeypatch.setattr(
+        manager_module,
+        "_rapid_mlx_running",
+        lambda _url: _coro(False),
+    )
+
+    mgr = RapidMLXManager(tmp_path)
+
+    summary = await mgr.uninstall(delete_models=True)
+
+    assert summary["removed_models"] == [target_repo]
+    # The big check: freed_bytes is the real blob size, NOT 2× (which is
+    # what we'd get if symlinks weren't filtered).
+    assert summary["freed_bytes"] == expected_freed, (
+        f"got {summary['freed_bytes']}, expected {expected_freed} "
+        f"(naive symlink-following would have given {naive_double})"
+    )
+    # Directory is actually gone.
+    assert not (hub / f"models--{target_repo.replace('/', '--')}").exists()
+
+
+@pytest.mark.asyncio
+async def test_uninstall_skips_uncached_models(monkeypatch, tmp_path: Path):
+    """If a known alias isn't cached on disk, it shouldn't show up in
+    removed_models — and shouldn't contribute to freed_bytes."""
+    hub = _make_hf_cache(tmp_path)
+    monkeypatch.setattr(manager_module, "_huggingface_cache_dir", lambda: hub)
+    monkeypatch.setattr(
+        manager_module,
+        "_rapid_mlx_running",
+        lambda _url: _coro(False),
+    )
+
+    mgr = RapidMLXManager(tmp_path)
+    summary = await mgr.uninstall(delete_models=True)
+
+    assert summary["removed_models"] == []
+    assert summary["freed_bytes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_uninstall_keeps_models_when_flag_false(monkeypatch, tmp_path: Path):
+    """delete_models=False should leave HF cache untouched."""
+    hub = _make_hf_cache(tmp_path)
+    from app.rapid_mlx.catalog import RAPID_MLX_ALIAS_REPOS, resolve_rapid_mlx_repo
+
+    target_repo = resolve_rapid_mlx_repo(next(iter(RAPID_MLX_ALIAS_REPOS)))
+    cache_dir = _make_cached_repo(hub, target_repo, [500])
+
+    monkeypatch.setattr(manager_module, "_huggingface_cache_dir", lambda: hub)
+    monkeypatch.setattr(
+        manager_module,
+        "_rapid_mlx_running",
+        lambda _url: _coro(False),
+    )
+
+    mgr = RapidMLXManager(tmp_path)
+    summary = await mgr.uninstall(delete_models=False)
+
+    assert summary["removed_models"] == []
+    assert summary["freed_bytes"] == 0
+    assert cache_dir.exists()
+
+
+def test_uninstall_includes_binary_removal_commands(monkeypatch, tmp_path: Path):
+    """The dialog renders these so the user can copy/paste — keep
+    brew + pip both in the response."""
+    hub = _make_hf_cache(tmp_path)
+    monkeypatch.setattr(manager_module, "_huggingface_cache_dir", lambda: hub)
+    monkeypatch.setattr(
+        manager_module,
+        "_rapid_mlx_running",
+        lambda _url: _coro(False),
+    )
+
+    mgr = RapidMLXManager(tmp_path)
+    import asyncio as _asyncio
+
+    summary = _asyncio.run(mgr.uninstall(delete_models=False))
+    cmds = summary["binary_install_commands"]
+    assert any("brew uninstall" in c for c in cmds)
+    assert any("pip uninstall rapid-mlx" in c for c in cmds)
+
+
+async def _coro(value):
+    """Helper: turn a value into an awaitable, since the function under
+    test does ``await _rapid_mlx_running(...)``."""
+    return value


### PR DESCRIPTION
## Summary

Closes the last open item (item 4) in #109 — unit coverage for the custom-provider + Rapid-MLX-uninstall logic landed in #108 / #110 / #111. Smoke tests verified everything at the time but nothing was guarding against regressions.

**91 new tests** across three files (all backend, no frontend test infra to set up):

- **\`tests/test_api/test_custom_endpoint_schema.py\`** (new, 79 cases) — slug validation (every \`RESERVED_CUSTOM_SLUGS\` entry incl. the full BYOK catalog, format rules, length limits, whitespace/case normalisation) and header validation. For the PATCH path, the JSON Merge Patch delta validator gets its own block: \`null\` for deletion is accepted with reduced value validation, but name rules (forbidden \`Host\` etc.) still apply.

- **\`tests/test_provider/test_provider_registry.py\`** (extended, +7 cases) — \`refresh_provider(pid)\` semantics. Critical assertion: refreshing one provider leaves the others' \`list_models\` / \`clear_cache\` calls at zero. Also covers direct-beats-aggregator priority survival, fallback to aggregator when a direct provider drops a model, removed-models vanishing from both \`_full_models\` and \`_model_index\`, and failure-preserves-prior-state.

- **\`tests/test_rapid_mlx/test_rapid_mlx_manager.py\`** (extended, +4 cases) — \`uninstall(delete_models=True)\` accounting. The headline test rebuilds the real HF cache layout (\`blobs/<sha>\` real files + \`snapshots/<rev>/<file>\` symlinks pointing at them) and asserts \`freed_bytes\` equals the real blob size, not 2× that — the very bug #110 fixed. Plus uncached-skip, \`delete_models=False\` keeping files, and binary-removal commands surfaced for the dialog.

## Test plan

- [ ] \`cd backend && .venv/bin/python -m pytest tests/test_api/test_custom_endpoint_schema.py tests/test_provider/ tests/test_rapid_mlx/\` — all 147 tests pass (140 + 7 skipped due to external prereqs)
- [ ] Verify CI picks up the new files (no \`__init__\` magic needed — pytest auto-discovers)