### PR TITLE
Add multi-agent task batch composer

### DIFF
--- a/frontend/src/components/chat/chat-form.tsx
+++ b/frontend/src/components/chat/chat-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from 'react-i18next';
-import { Check, ChevronDown, Plus } from "lucide-react";
+import { Check, ChevronDown, GitBranch, Play, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ChatTextarea } from "./chat-textarea";
@@ -20,12 +20,15 @@ import { useChatStore } from "@/stores/chat-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useProviderModels } from "@/hooks/use-provider-models";
 import { useIndexStatus } from "@/hooks/use-index-status";
+import { useAgents } from "@/hooks/use-agents";
 import { IS_DESKTOP } from "@/lib/constants";
+import type { TaskBatchMode, TaskBatchTask } from "@/types/chat";
 
 interface ChatFormProps {
   isGenerating: boolean;
   isCompacting?: boolean;
   onSend: (text: string, attachments?: FileAttachment[]) => Promise<boolean> | void;
+  onSendTaskBatch?: (batch: { mode: TaskBatchMode; tasks: TaskBatchTask[] }) => Promise<boolean> | void;
   onStop: () => void;
   className?: string;
   sessionId?: string;
@@ -38,6 +41,15 @@ interface Draft {
   attachments: FileAttachment[];
   savedAt: number;
 }
+
+type TaskDraft = {
+  id: string;
+  title: string;
+  prompt: string;
+  agent: string;
+  model: string;
+  provider_id: string;
+};
 
 const DRAFT_STORAGE_KEY = "openyak-drafts";
 const DRAFT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -207,19 +219,27 @@ function detectMention(
   return { active: true, query, startIndex: atIndex };
 }
 
-export function ChatForm({ isGenerating, isCompacting = false, onSend, onStop, className, sessionId, directory }: ChatFormProps) {
+export function ChatForm({ isGenerating, isCompacting = false, onSend, onSendTaskBatch, onStop, className, sessionId, directory }: ChatFormProps) {
   const { t } = useTranslation('chat');
   const [input, setInput] = useState("");
   const [attachments, setAttachments] = useState<FileAttachment[]>([]);
   const [uploading, setUploading] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [batchOpen, setBatchOpen] = useState(false);
+  const [batchMode, setBatchMode] = useState<TaskBatchMode>("parallel");
+  const [batchTasks, setBatchTasks] = useState<TaskDraft[]>([]);
   const { ref, resize } = useAutoResize();
   const dropTargetRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { data: providerModels, activeProvider } = useProviderModels();
+  const { data: agents } = useAgents();
+  const selectedAgent = useSettingsStore((s) => s.selectedAgent);
+  const selectedModel = useSettingsStore((s) => s.selectedModel);
+  const selectedProviderId = useSettingsStore((s) => s.selectedProviderId);
   const noModelsAvailable = !activeProvider || providerModels.length === 0;
 
   const sendingRef = useRef(false);
+  const taskDraftIdRef = useRef(0);
   const tauriDropHandledAtRef = useRef(0);
 
   // Track latest values for draft save-on-unmount (avoids stale closures)
@@ -278,6 +298,58 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onStop, c
     return null;
   });
   const isInputDisabled = isGenerating || isCompacting || noModelsAvailable;
+  const visibleAgents = useMemo(
+    () => (agents ?? []).filter((agent) => agent.mode !== "hidden"),
+    [agents],
+  );
+  const defaultBatchAgents = useMemo(() => {
+    const subagents = visibleAgents.filter((agent) => agent.mode === "subagent");
+    return subagents.length > 0 ? subagents : visibleAgents;
+  }, [visibleAgents]);
+
+  const createTaskDraft = useCallback((index: number, prompt = ""): TaskDraft => {
+    const agentName = defaultBatchAgents[index]?.name ?? defaultBatchAgents[0]?.name ?? selectedAgent ?? "build";
+    taskDraftIdRef.current += 1;
+    return {
+      id: `task-${Date.now()}-${taskDraftIdRef.current}`,
+      title: agentName === "build" || agentName === "plan" ? `Task ${index + 1}` : agentName,
+      prompt,
+      agent: agentName,
+      model: selectedModel ?? "",
+      provider_id: selectedProviderId ?? "",
+    };
+  }, [defaultBatchAgents, selectedAgent, selectedModel, selectedProviderId]);
+
+  const handleBatchOpenChange = useCallback((open: boolean) => {
+    setBatchOpen(open);
+    if (open && batchTasks.length === 0) {
+      setBatchTasks([
+        createTaskDraft(0, input.trim()),
+        createTaskDraft(1),
+      ]);
+    }
+  }, [batchTasks.length, createTaskDraft, input]);
+
+  const updateBatchTask = useCallback((id: string, patch: Partial<TaskDraft>) => {
+    setBatchTasks((prev) => prev.map((task) => task.id === id ? { ...task, ...patch } : task));
+  }, []);
+
+  const addBatchTask = useCallback(() => {
+    setBatchTasks((prev) => [...prev, createTaskDraft(prev.length)]);
+  }, [createTaskDraft]);
+
+  const removeBatchTask = useCallback((id: string) => {
+    setBatchTasks((prev) => prev.length > 1 ? prev.filter((task) => task.id !== id) : prev);
+  }, []);
+
+  const useInputForFirstTask = useCallback(() => {
+    const text = input.trim();
+    if (!text) return;
+    setBatchTasks((prev) => {
+      const next = prev.length > 0 ? prev : [createTaskDraft(0)];
+      return next.map((task, index) => index === 0 ? { ...task, prompt: text } : task);
+    });
+  }, [createTaskDraft, input]);
 
   const addAttachments = useCallback((files: FileAttachment[]) => {
     setAttachments((prev) => {
@@ -436,6 +508,43 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onStop, c
     }
   }, [input, attachments, isGenerating, isCompacting, onSend, ref, draftKey]);
 
+  const handleSendTaskBatch = useCallback(async () => {
+    if (!onSendTaskBatch || isGenerating || isCompacting || sendingRef.current) return;
+    if (attachments.length > 0) {
+      toast.error("Task batches do not support attachments yet.");
+      return;
+    }
+
+    const hasIncompleteTask = batchTasks.some((task) => !task.title.trim() || !task.prompt.trim());
+    if (hasIncompleteTask) {
+      toast.error("Each task needs a title and prompt.");
+      return;
+    }
+
+    const tasks = batchTasks.map((task) => ({
+      title: task.title.trim(),
+      prompt: task.prompt.trim(),
+      agent: task.agent || selectedAgent || "build",
+      model: task.model || null,
+      provider_id: task.provider_id || null,
+    }));
+    if (tasks.length === 0) return;
+
+    sendingRef.current = true;
+    try {
+      const result = await onSendTaskBatch({ mode: batchMode, tasks });
+      if (result !== false) {
+        setBatchOpen(false);
+        setBatchTasks([]);
+        setInput("");
+        inputRef.current = "";
+        deleteDraft(draftKey);
+      }
+    } finally {
+      sendingRef.current = false;
+    }
+  }, [attachments.length, batchMode, batchTasks, draftKey, isCompacting, isGenerating, onSendTaskBatch, selectedAgent]);
+
   const handleBrowse = useCallback(async () => {
     setUploading(true);
     try {
@@ -554,6 +663,11 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onStop, c
     }
     return t("contextCompactingNow");
   }, [compactingLabel, isCompacting, t]);
+  const canStartTaskBatch = !!onSendTaskBatch &&
+    batchTasks.length > 0 &&
+    batchTasks.every((task) => task.title.trim() && task.prompt.trim()) &&
+    !isInputDisabled &&
+    !isIndexing;
 
   return (
     <div className={cn("px-4 pb-4", className)}>
@@ -655,6 +769,154 @@ export function ChatForm({ isGenerating, isCompacting = false, onSend, onStop, c
             <div className={cn(isInputDisabled && "pointer-events-none opacity-50")}>
               <AgentToggle />
             </div>
+
+            {onSendTaskBatch && (
+              <Popover open={batchOpen} onOpenChange={handleBatchOpenChange}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={isInputDisabled}
+                    className="shrink-0 flex items-center justify-center h-8 w-8 rounded-full hover:bg-[var(--surface-tertiary)] transition-colors text-[var(--text-secondary)] disabled:opacity-50"
+                    aria-label="Multi-agent tasks"
+                    title="Multi-agent tasks"
+                  >
+                    <GitBranch className="h-4 w-4" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" sideOffset={8} className="w-[min(720px,calc(100vw-32px))] p-3">
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="flex rounded-full bg-[var(--surface-secondary)] p-0.5">
+                        {(["parallel", "sequential"] as TaskBatchMode[]).map((mode) => (
+                          <button
+                            key={mode}
+                            type="button"
+                            onClick={() => setBatchMode(mode)}
+                            className={cn(
+                              "rounded-full px-3 py-1.5 text-[12px] font-medium capitalize transition-colors",
+                              batchMode === mode
+                                ? "bg-[var(--surface-primary)] text-[var(--text-primary)] shadow-[var(--shadow-sm)]"
+                                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]",
+                            )}
+                          >
+                            {mode}
+                          </button>
+                        ))}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={useInputForFirstTask}
+                        disabled={!input.trim()}
+                        className="rounded-full px-3 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] hover:bg-[var(--surface-secondary)] disabled:opacity-40"
+                      >
+                        Use input
+                      </button>
+                      <div className="flex-1" />
+                      <button
+                        type="button"
+                        onClick={addBatchTask}
+                        className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-medium text-[var(--text-secondary)] hover:bg-[var(--surface-secondary)]"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Add task
+                      </button>
+                    </div>
+
+                    <div className="max-h-[55vh] overflow-y-auto pr-1">
+                      <div className="grid gap-2">
+                        {batchTasks.map((task, index) => (
+                          <div
+                            key={task.id}
+                            className="rounded-lg border border-[var(--border-default)] bg-[var(--surface-primary)] p-3"
+                          >
+                            <div className="flex items-center gap-2">
+                              <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-secondary)] text-[12px] font-medium text-[var(--text-secondary)]">
+                                {index + 1}
+                              </span>
+                              <input
+                                value={task.title}
+                                onChange={(e) => updateBatchTask(task.id, { title: e.target.value })}
+                                placeholder="Task title"
+                                className="min-w-0 flex-1 rounded-md border border-[var(--border-default)] bg-[var(--surface-primary)] px-2.5 py-1.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-heavy)]"
+                              />
+                              <button
+                                type="button"
+                                onClick={() => removeBatchTask(task.id)}
+                                disabled={batchTasks.length <= 1}
+                                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[var(--text-tertiary)] hover:bg-[var(--surface-secondary)] hover:text-[var(--text-primary)] disabled:opacity-35"
+                                aria-label="Remove task"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </div>
+                            <textarea
+                              value={task.prompt}
+                              onChange={(e) => updateBatchTask(task.id, { prompt: e.target.value })}
+                              placeholder="Prompt for this agent"
+                              rows={3}
+                              className="mt-2 w-full resize-none rounded-md border border-[var(--border-default)] bg-[var(--surface-primary)] px-2.5 py-2 text-[13px] leading-relaxed text-[var(--text-primary)] outline-none placeholder:text-[var(--text-tertiary)] focus:border-[var(--border-heavy)]"
+                            />
+                            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                              <select
+                                value={task.agent}
+                                onChange={(e) => updateBatchTask(task.id, { agent: e.target.value })}
+                                className="min-w-0 rounded-md border border-[var(--border-default)] bg-[var(--surface-primary)] px-2.5 py-1.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-heavy)]"
+                              >
+                                {visibleAgents.length === 0 && (
+                                  <option value={task.agent}>{task.agent}</option>
+                                )}
+                                {visibleAgents.map((agent) => (
+                                  <option key={agent.name} value={agent.name}>
+                                    {agent.name}
+                                  </option>
+                                ))}
+                              </select>
+                              <select
+                                value={task.model && task.provider_id ? `${task.provider_id}::${task.model}` : ""}
+                                onChange={(e) => {
+                                  const [providerId, modelId] = e.target.value.split("::");
+                                  updateBatchTask(task.id, {
+                                    provider_id: providerId || "",
+                                    model: modelId || "",
+                                  });
+                                }}
+                                className="min-w-0 rounded-md border border-[var(--border-default)] bg-[var(--surface-primary)] px-2.5 py-1.5 text-[13px] text-[var(--text-primary)] outline-none focus:border-[var(--border-heavy)]"
+                              >
+                                <option value="">Current model</option>
+                                {providerModels.map((model) => (
+                                  <option key={`${model.provider_id}:${model.id}`} value={`${model.provider_id}::${model.id}`}>
+                                    {model.name}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center justify-end gap-2 border-t border-[var(--border-default)] pt-3">
+                      <button
+                        type="button"
+                        onClick={() => setBatchOpen(false)}
+                        className="rounded-full px-3 py-1.5 text-[13px] font-medium text-[var(--text-secondary)] hover:bg-[var(--surface-secondary)]"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleSendTaskBatch}
+                        disabled={!canStartTaskBatch}
+                        className="inline-flex items-center gap-1.5 rounded-full bg-[var(--text-primary)] px-3 py-1.5 text-[13px] font-medium text-[var(--surface-primary)] transition-opacity disabled:opacity-40"
+                      >
+                        <Play className="h-3.5 w-3.5" />
+                        Start batch
+                      </button>
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
 
             <div className="flex-1" />
 

--- a/frontend/src/components/chat/chat-view.tsx
+++ b/frontend/src/components/chat/chat-view.tsx
@@ -28,6 +28,7 @@ interface ChatViewProps {
 export function ChatView({ sessionId }: ChatViewProps) {
   const {
     sendMessage,
+    sendTaskBatch,
     editAndResend,
     stopGeneration,
     respondToPermission,
@@ -230,6 +231,7 @@ export function ChatView({ sessionId }: ChatViewProps) {
           isGenerating={isGenerating}
           isCompacting={isCompacting || !!session?.time_compacting}
           onSend={sendMessage}
+          onSendTaskBatch={sendTaskBatch}
           onStop={stopGeneration}
           sessionId={sessionId}
           directory={session?.directory}

--- a/frontend/src/components/chat/landing.tsx
+++ b/frontend/src/components/chat/landing.tsx
@@ -57,7 +57,7 @@ function pickRandomStarters(count: number): typeof FEATURED_STARTERS {
 
 export function Landing({ directoryParam = null }: LandingProps) {
   const { t } = useTranslation('chat');
-  const { sendMessage, isGenerating, stopGeneration, pendingUserText, pendingAttachments, streamingParts, streamingText, streamingReasoning } = useChat();
+  const { sendMessage, sendTaskBatch, isGenerating, stopGeneration, pendingUserText, pendingAttachments, streamingParts, streamingText, streamingReasoning } = useChat();
   const globalWorkspace = useSettingsStore((s) => s.workspaceDirectory);
   const workspaceName = workspaceBasename(globalWorkspace);
   const activeProvider = useSettingsStore((s) => s.activeProvider);
@@ -157,6 +157,7 @@ export function Landing({ directoryParam = null }: LandingProps) {
         <ChatForm
           isGenerating={isGenerating}
           onSend={sendMessage}
+          onSendTaskBatch={sendTaskBatch}
           onStop={stopGeneration}
           directory={globalWorkspace}
         />
@@ -210,6 +211,7 @@ export function Landing({ directoryParam = null }: LandingProps) {
           <ChatForm
             isGenerating={isGenerating}
             onSend={sendMessage}
+            onSendTaskBatch={sendTaskBatch}
             onStop={stopGeneration}
             directory={globalWorkspace}
           />

--- a/frontend/src/hooks/use-chat.ts
+++ b/frontend/src/hooks/use-chat.ts
@@ -14,7 +14,7 @@ import { useActivityStore } from "@/stores/activity-store";
 import { useSSE } from "./use-sse";
 import { useRemoteGenerationSync } from "./use-remote-generation-sync";
 import type { InfiniteData } from "@tanstack/react-query";
-import type { FileAttachment, PromptResponse, RespondRequest } from "@/types/chat";
+import type { FileAttachment, PromptResponse, RespondRequest, TaskBatchRequest } from "@/types/chat";
 import type { PaginatedMessages } from "@/types/message";
 import type { SessionResponse } from "@/types/session";
 import type { ModelInfo } from "@/types/model";
@@ -55,6 +55,12 @@ function isUnsupportedImagesError(err: unknown): boolean {
     detail !== null &&
     (detail as { code?: unknown }).code === MODEL_DOES_NOT_SUPPORT_IMAGES
   );
+}
+
+function formatTaskBatchPrompt(batch: Pick<TaskBatchRequest, "mode" | "tasks">): string {
+  const heading = batch.mode === "parallel" ? "Run tasks in parallel" : "Run tasks sequentially";
+  const lines = batch.tasks.map((task, index) => `${index + 1}. ${task.title}`);
+  return [heading, ...lines].join("\n");
 }
 
 /**
@@ -209,6 +215,99 @@ export function useChat(currentSessionId?: string) {
         }
 
         toast.error("Failed to send message", { duration: 8000 });
+        return false;
+      }
+    },
+    [currentSessionId, router, queryClient],
+  );
+
+  const sendTaskBatch = useCallback(
+    async (batch: Pick<TaskBatchRequest, "mode" | "tasks">): Promise<boolean> => {
+      const chatState = useChatStore.getState();
+      const settingsState = useSettingsStore.getState();
+      const tasks = batch.tasks
+        .map((task) => ({
+          ...task,
+          title: task.title.trim(),
+          prompt: task.prompt.trim(),
+          agent: task.agent || settingsState.selectedAgent,
+          model: task.model || settingsState.selectedModel,
+          provider_id: task.provider_id || settingsState.selectedProviderId,
+        }))
+        .filter((task) => task.title && task.prompt);
+
+      if (chatState.isGenerating || chatState.isCompacting || tasks.length === 0) return false;
+
+      if (!currentSessionId) {
+        chatState.reset();
+      }
+
+      useActivityStore.getState().close();
+      try {
+        const { useArtifactStore } = require("@/stores/artifact-store");
+        useArtifactStore.getState().close();
+      } catch {}
+      try {
+        const { usePlanReviewStore } = require("@/stores/plan-review-store");
+        usePlanReviewStore.getState().close();
+      } catch {}
+
+      const optimisticText = formatTaskBatchPrompt({ mode: batch.mode, tasks });
+      chatState.beginSending(optimisticText);
+
+      try {
+        const res = await api.post<PromptResponse>(API.CHAT.TASK_BATCH, {
+          session_id: currentSessionId ?? null,
+          mode: batch.mode,
+          tasks,
+          workspace: settingsState.workspaceDirectory,
+        });
+
+        chatState.startGeneration(res.stream_id, res.session_id);
+
+        if (!currentSessionId) {
+          const tempSession: SessionResponse = {
+            id: res.session_id,
+            project_id: null,
+            parent_id: null,
+            slug: null,
+            directory: settingsState.workspaceDirectory || null,
+            title: tasks[0]?.title?.slice(0, 60) || "Multi-agent task batch",
+            version: 0,
+            summary_additions: 0,
+            summary_deletions: 0,
+            summary_files: 0,
+            summary_diffs: [],
+            is_pinned: false,
+            permission: {},
+            time_created: new Date().toISOString(),
+            time_updated: new Date().toISOString(),
+            time_compacting: null,
+            time_archived: null,
+          };
+          queryClient.setQueryData<InfiniteData<SessionResponse[]>>(
+            queryKeys.sessions.all,
+            (old) => {
+              if (!old) return { pages: [[tempSession]], pageParams: [0] };
+              return {
+                ...old,
+                pages: [[tempSession, ...old.pages[0]], ...old.pages.slice(1)],
+              };
+            },
+          );
+          router.push(getChatRoute(res.session_id));
+        }
+        return true;
+      } catch (err) {
+        console.error("Failed to start task batch:", err);
+        useChatStore.getState().reset();
+
+        if (err instanceof ApiError) {
+          toast.error(err.message, { duration: 8000 });
+          return false;
+        }
+
+        toast.error("Failed to start task batch", { duration: 8000 });
         return false;
       }
     },
@@ -469,6 +568,7 @@ export function useChat(currentSessionId?: string) {
 
   return {
     sendMessage,
+    sendTaskBatch,
     editAndResend,
     stopGeneration,
     respondToPermission,

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -29,6 +29,23 @@ export interface PromptResponse {
   session_id: string;
 }
 
+export type TaskBatchMode = "sequential" | "parallel";
+
+export interface TaskBatchTask {
+  title: string;
+  prompt: string;
+  agent: string;
+  model?: string | null;
+  provider_id?: string | null;
+}
+
+export interface TaskBatchRequest {
+  session_id?: string | null;
+  mode: TaskBatchMode;
+  tasks: TaskBatchTask[];
+  workspace?: string | null;
+}
+
 export interface EditAndResendRequest {
   session_id: string;
   message_id: string;


### PR DESCRIPTION
## Summary
- add a multi-agent task composer popover to the chat input
- support parallel/sequential batches with editable task title, prompt, agent, and model
- wire the composer through useChat to the existing task-batch API and show an optimistic user message

## Testing
- npm run lint
- ./.venv/bin/pytest tests/test_session/test_task_batch.py
- verified in the in-app browser: opened the composer, edited tasks, selected defaults, and started a real batch; the UI streamed and rendered the batch result. The final child runs hit the local Rapid-MLX compatible endpoint connection error, which is provider connectivity rather than frontend wiring.

Closes #116