### PR TITLE
Fix Rapid-MLX default model readiness

### DIFF
--- a/backend/app/api/rapid_mlx.py
+++ b/backend/app/api/rapid_mlx.py
@@ -23,7 +23,7 @@ class RapidMLXRuntimeStatus(BaseModel):
     port: int = DEFAULT_PORT
     base_url: str | None = None
     version: str | None = None
-    current_model: str = "default"
+    current_model: str = "qwen3.5-4b"
     executable_path: str | None = None
     install_commands: list[str] = Field(default_factory=list)
 
@@ -116,11 +116,13 @@ async def start_rapid_mlx(
         raise HTTPException(400, str(exc))
 
     from app.api.config import _update_env_file
+    from app.provider.rapid_mlx import normalize_rapid_mlx_model
 
+    model = normalize_rapid_mlx_model(body.model)
     _update_env_file("OPENYAK_RAPID_MLX_BASE_URL", base_url)
-    _update_env_file("OPENYAK_RAPID_MLX_MODEL", body.model)
+    _update_env_file("OPENYAK_RAPID_MLX_MODEL", model)
     settings.rapid_mlx_base_url = base_url
-    settings.rapid_mlx_model = body.model
+    settings.rapid_mlx_model = model
 
     data = await mgr.status(
         configured_base_url=settings.rapid_mlx_base_url,
@@ -191,6 +193,10 @@ async def _register_rapid_mlx_provider(
         existing is not None
         and getattr(existing, "_base_url", None) == base_url.rstrip("/")
     ):
+        try:
+            await registry.refresh_provider("rapid-mlx")
+        except Exception as exc:
+            logger.warning("Failed to refresh existing Rapid-MLX provider: %s", exc)
         return
 
     registry.register(RapidMLXProvider(base_url=base_url))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -199,7 +199,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.rapid_mlx_manager = rapid_mlx_manager
 
     if settings.rapid_mlx_base_url:
-        from app.provider.rapid_mlx import RapidMLXProvider
+        from app.provider.rapid_mlx import RapidMLXProvider, normalize_rapid_mlx_model
+
+        normalized_rapid_mlx_model = normalize_rapid_mlx_model(settings.rapid_mlx_model)
+        if normalized_rapid_mlx_model != settings.rapid_mlx_model:
+            from app.api.config import _update_env_file
+
+            _update_env_file("OPENYAK_RAPID_MLX_MODEL", normalized_rapid_mlx_model)
+        settings.rapid_mlx_model = normalized_rapid_mlx_model
 
         if (
             rapid_mlx_manager.platform_supported

--- a/backend/app/provider/rapid_mlx.py
+++ b/backend/app/provider/rapid_mlx.py
@@ -20,15 +20,26 @@ logger = logging.getLogger(__name__)
 
 PROVIDER_ID = "rapid-mlx"
 DEFAULT_BASE_URL = "http://localhost:18080/v1"
-DEFAULT_MODEL = "default"
+DEFAULT_MODEL = "qwen3.5-4b"
+LEGACY_DEFAULT_MODEL = "default"
+
+
+def normalize_rapid_mlx_model(name: str | None) -> str:
+    """Map old OpenYak defaults to a real rapid-mlx alias."""
+    value = (name or "").strip().removeprefix(f"{PROVIDER_ID}/").strip()
+    if not value or value == LEGACY_DEFAULT_MODEL:
+        return DEFAULT_MODEL
+    return value
 
 
 def _model_id(name: str) -> str:
-    return name if name.startswith(f"{PROVIDER_ID}/") else f"{PROVIDER_ID}/{name}"
+    normalized = normalize_rapid_mlx_model(name)
+    return normalized if normalized.startswith(f"{PROVIDER_ID}/") else f"{PROVIDER_ID}/{normalized}"
 
 
 def _model_name(name: str) -> str:
-    return "Rapid-MLX Default" if name == DEFAULT_MODEL else name
+    normalized = normalize_rapid_mlx_model(name)
+    return "Rapid-MLX Qwen 3.5 4B" if normalized == DEFAULT_MODEL else normalized
 
 
 def _rapid_capabilities(model: str = DEFAULT_MODEL) -> ModelCapabilities:
@@ -68,7 +79,7 @@ class RapidMLXProvider(OpenAICompatProvider):
             response = await self._client.models.list()
             seen: set[str] = set()
             for item in response.data:
-                name = item.id or DEFAULT_MODEL
+                name = normalize_rapid_mlx_model(item.id or DEFAULT_MODEL)
                 if name in seen:
                     continue
                 seen.add(name)
@@ -84,21 +95,10 @@ class RapidMLXProvider(OpenAICompatProvider):
                 )
         except Exception as exc:
             logger.debug(
-                "Rapid-MLX: /v1/models unavailable, using default model: %s",
+                "Rapid-MLX: /v1/models unavailable: %s",
                 exc,
             )
-
-        if not models:
-            models = [
-                ModelInfo(
-                    id=_model_id(DEFAULT_MODEL),
-                    name=_model_name(DEFAULT_MODEL),
-                    provider_id=self.id,
-                    capabilities=_rapid_capabilities(DEFAULT_MODEL),
-                    pricing=ModelPricing(prompt=0.0, completion=0.0),
-                    metadata={"local": True},
-                )
-            ]
+            return []
 
         self._models_cache = models
         return models
@@ -109,7 +109,7 @@ class RapidMLXProvider(OpenAICompatProvider):
         messages: list[dict[str, Any]],
         **kwargs: Any,
     ):
-        bare_model = model.removeprefix(f"{PROVIDER_ID}/") or DEFAULT_MODEL
+        bare_model = normalize_rapid_mlx_model(model)
         async for chunk in super().stream_chat(bare_model, messages, **kwargs):
             yield chunk
 

--- a/backend/app/rapid_mlx/manager.py
+++ b/backend/app/rapid_mlx/manager.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import httpx
 
-from app.provider.rapid_mlx import DEFAULT_BASE_URL, DEFAULT_MODEL
+from app.provider.rapid_mlx import DEFAULT_BASE_URL, DEFAULT_MODEL, normalize_rapid_mlx_model
 from app.rapid_mlx.catalog import (
     RAPID_MLX_ALIAS_REPOS,
     canonical_rapid_mlx_model,
@@ -87,7 +87,7 @@ class RapidMLXManager:
         self._port = port
         running = await _rapid_mlx_running(base_url)
         version = await self._version() if self.is_binary_installed else None
-        model = configured_model or self._model or DEFAULT_MODEL
+        model = normalize_rapid_mlx_model(configured_model or self._model or DEFAULT_MODEL)
         return {
             "platform_supported": self.platform_supported,
             "binary_installed": self.is_binary_installed,
@@ -161,7 +161,7 @@ class RapidMLXManager:
         if not executable:
             raise RuntimeError("rapid-mlx is not installed.")
 
-        next_model = model.strip() or DEFAULT_MODEL
+        next_model = normalize_rapid_mlx_model(model)
         next_identity = canonical_rapid_mlx_model(next_model)
         base_url = _base_url_for_port(port)
         if await _rapid_mlx_running(base_url):

--- a/backend/app/session/prompt.py
+++ b/backend/app/session/prompt.py
@@ -239,8 +239,12 @@ class SessionPrompt:
         elif self.provider.id == "rapid-mlx":
             try:
                 from app.api.config import _update_env_file
+                from app.provider.rapid_mlx import normalize_rapid_mlx_model
 
-                _update_env_file("OPENYAK_RAPID_MLX_MODEL", model_id.removeprefix("rapid-mlx/"))
+                _update_env_file(
+                    "OPENYAK_RAPID_MLX_MODEL",
+                    normalize_rapid_mlx_model(model_id),
+                )
             except Exception:
                 pass
 

--- a/backend/tests/test_provider/test_rapid_mlx.py
+++ b/backend/tests/test_provider/test_rapid_mlx.py
@@ -35,18 +35,13 @@ class _ModelsClient:
 
 
 @pytest.mark.asyncio
-async def test_rapid_mlx_falls_back_to_default_model():
+async def test_rapid_mlx_returns_no_models_when_runtime_is_unavailable():
     provider = RapidMLXProvider()
     provider._client = _Client()
 
     models = await provider.list_models()
 
-    assert len(models) == 1
-    assert models[0].id == "rapid-mlx/default"
-    assert models[0].provider_id == "rapid-mlx"
-    assert models[0].pricing.prompt == 0
-    assert models[0].capabilities.function_calling is True
-    assert models[0].capabilities.prompt_caching is True
+    assert models == []
 
 
 @pytest.mark.asyncio
@@ -59,3 +54,21 @@ async def test_rapid_mlx_marks_known_vision_models():
 
     assert by_id["rapid-mlx/qwen3-vl-4b"].capabilities.vision is True
     assert by_id["rapid-mlx/qwen3.5-9b"].capabilities.vision is False
+
+
+@pytest.mark.asyncio
+async def test_rapid_mlx_maps_legacy_default_model(monkeypatch):
+    provider = RapidMLXProvider()
+    chunks = []
+
+    async def fake_stream(self, model, messages, **kwargs):
+        chunks.append((model, messages, kwargs))
+        if False:
+            yield None
+
+    monkeypatch.setattr("app.provider.openai_compat.OpenAICompatProvider.stream_chat", fake_stream)
+
+    async for _ in provider.stream_chat("rapid-mlx/default", [{"role": "user", "content": "hi"}]):
+        pass
+
+    assert chunks[0][0] == "qwen3.5-4b"


### PR DESCRIPTION
## Summary
- migrate legacy Rapid-MLX default model config to the real qwen3.5-4b alias
- stop exposing cached fallback Rapid-MLX models while the runtime is unavailable
- refresh an existing Rapid-MLX provider after the runtime becomes healthy so /api/models updates correctly

## Root cause
The connection issue came from a stale Rapid-MLX model config: default is no longer a valid rapid-mlx 0.6.20 alias. OpenYak still exposed rapid-mlx/default as a fallback model while the runtime was down or still starting, so the UI could select a provider/model that could not actually serve requests.

## Testing
- ./.venv/bin/pytest tests/test_provider/test_rapid_mlx.py tests/test_session/test_task_batch.py
- Verified rapid-mlx serve qwen3.5-4b exposes http://127.0.0.1:18080/v1/models
- Verified direct /v1/chat/completions returns a real Rapid-MLX response
- Verified /api/models lists rapid-mlx/qwen3.5-4b and no longer lists rapid-mlx/default
- Verified real task batches in the in-app browser: parallel and sequential batches both completed child tasks.